### PR TITLE
Use https in github repo SRC_URIS

### DIFF
--- a/recipes-containers/containerd/containerd-docker_git.bb
+++ b/recipes-containers/containerd/containerd-docker_git.bb
@@ -1,6 +1,6 @@
 SRCREV = "3addd840653146c90a254301d6c3a663c7fd6429"
 SRC_URI = "\
-	git://github.com/docker/containerd.git;branch=v0.2.x;destsuffix=git/src/github.com/containerd/containerd \
+	git://github.com/docker/containerd.git;branch=v0.2.x;destsuffix=git/src/github.com/containerd/containerd;protocol=https \
 	"
 
 include containerd.inc

--- a/recipes-containers/containerd/containerd-opencontainers_git.bb
+++ b/recipes-containers/containerd/containerd-opencontainers_git.bb
@@ -1,5 +1,5 @@
 SRCREV = "cfd04396dc68220d1cecbe686a6cc3aa5ce3667c"
-SRC_URI = "git://github.com/containerd/containerd;nobranch=1 \
+SRC_URI = "git://github.com/containerd/containerd;nobranch=1;protocol=https \
            file://0001-build-use-oe-provided-GO-and-flags.patch \
           "
 

--- a/recipes-containers/cri-o/cri-o_git.bb
+++ b/recipes-containers/cri-o/cri-o_git.bb
@@ -16,7 +16,7 @@ At a high level, we expect the scope of cri-o to be restricted to the following 
 
 SRCREV_cri-o = "65faae67828fb3eb3eac05b582aae9f9d1dea51c"
 SRC_URI = "\
-	git://github.com/kubernetes-incubator/cri-o.git;nobranch=1;name=cri-o \
+	git://github.com/kubernetes-incubator/cri-o.git;nobranch=1;name=cri-o;protocol=https \
 	file://0001-Makefile-force-symlinks.patch \
         file://crio.conf \
 	"

--- a/recipes-containers/criu/criu_git.bb
+++ b/recipes-containers/criu/criu_git.bb
@@ -16,7 +16,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=412de458544c1cb6a2b512cd399286e2"
 SRCREV = "a31c1854e10580a09621e539c3ec052b875a8e06"
 PV = "3.4+git${SRCPV}"
 
-SRC_URI = "git://github.com/xemul/criu.git;protocol=git \
+SRC_URI = "git://github.com/xemul/criu.git;protocol=https \
            file://0001-criu-Fix-toolchain-hardcode.patch \
            file://0002-criu-Skip-documentation-install.patch \
            file://0001-criu-Change-libraries-install-directory.patch \

--- a/recipes-containers/docker-distribution/docker-distribution_git.bb
+++ b/recipes-containers/docker-distribution/docker-distribution_git.bb
@@ -4,7 +4,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d2794c0df5b907fdace235a619d80314"
 
 SRCREV_distribution="48294d928ced5dd9b378f7fd7c6f5da3ff3f2c89"
-SRC_URI = "git://github.com/docker/distribution.git;branch=release/2.6;name=distribution;destsuffix=git/src/github.com/docker/distribution \
+SRC_URI = "git://github.com/docker/distribution.git;branch=release/2.6;name=distribution;destsuffix=git/src/github.com/docker/distribution;protocol=https \
            file://docker-registry.service \
           "
 

--- a/recipes-containers/docker/docker-ce_git.bb
+++ b/recipes-containers/docker/docker-ce_git.bb
@@ -22,9 +22,9 @@ SRCREV_docker = "0520e243029d1361649afb0706a1c5d9a1c012b8"
 SRCREV_libnetwork = "4cb38c2987c236dce03c868d99b57b1e28a4b81c"
 SRCREV_cli = "0f1bb353423e45e02315e985bd9ddebe6da18457"
 SRC_URI = "\
-	git://github.com/docker/docker-ce.git;nobranch=1;name=docker \
-	git://github.com/docker/libnetwork.git;branch=master;name=libnetwork;destsuffix=libnetwork \
-	git://github.com/docker/cli;branch=master;name=cli;destsuffix=cli \
+	git://github.com/docker/docker-ce.git;nobranch=1;name=docker;protocol=https \
+	git://github.com/docker/libnetwork.git;branch=master;name=libnetwork;destsuffix=libnetwork;protocol=https \
+	git://github.com/docker/cli;branch=master;name=cli;destsuffix=cli;protocol=https \
 	file://docker.init \
 	file://hi.Dockerfile \
 	"

--- a/recipes-containers/docker/docker_git.bb
+++ b/recipes-containers/docker/docker_git.bb
@@ -22,9 +22,9 @@ SRCREV_docker = "708b068d3095c6a6be939eb2da78c921d2e945e2"
 SRCREV_libnetwork = "4cb38c2987c236dce03c868d99b57b1e28a4b81c"
 SRCREV_cli = "0f1bb353423e45e02315e985bd9ddebe6da18457"
 SRC_URI = "\
-	git://github.com/moby/moby.git;nobranch=1;name=docker \
-	git://github.com/docker/libnetwork.git;branch=master;name=libnetwork;destsuffix=git/libnetwork \
-	git://github.com/docker/cli;branch=master;name=cli;destsuffix=git/cli \
+	git://github.com/moby/moby.git;nobranch=1;name=docker;protocol=https \
+	git://github.com/docker/libnetwork.git;branch=master;name=libnetwork;destsuffix=git/libnetwork;protocol=https \
+	git://github.com/docker/cli;branch=master;name=cli;destsuffix=git/cli;protocol=https \
 	file://docker.init \
 	file://hi.Dockerfile \
         file://0001-libnetwork-use-GO-instead-of-go.patch \

--- a/recipes-containers/go-digest/go-digest_git.bb
+++ b/recipes-containers/go-digest/go-digest_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${PKG_NAME}/LICENSE.code;md5=9cd86830b557232ce55e
 SRCNAME = "go-digest"
 
 PKG_NAME = "github.com/opencontainers/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git;destsuffix=git/src/${PKG_NAME}"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https;destsuffix=git/src/${PKG_NAME}"
 
 SRCREV = "b6234c321f263c503268e3b205f3d9755f9d14ed"
 PV = "v1.0.0-rc0+git${SRCPV}"

--- a/recipes-containers/go-errors/go-errors_git.bb
+++ b/recipes-containers/go-errors/go-errors_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${PKG_NAME}/LICENSE;md5=6fe682a02df52c6653f33bd0f
 SRCNAME = "errors"
 
 PKG_NAME = "github.com/pkg/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git;destsuffix=git/src/${PKG_NAME}"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https;destsuffix=git/src/${PKG_NAME}"
 
 SRCREV = "248dadf4e9068a0b3e79f02ed0a610d935de5302"
 PV = "v0.8.0+git${SRCPV}"

--- a/recipes-containers/go-spf13-cobra/spf13-cobra_git.bb
+++ b/recipes-containers/go-spf13-cobra/spf13-cobra_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${PKG_NAME}/LICENSE.txt;md5=920d76114a32b0fb75b3f
 SRCNAME = "cobra"
 
 PKG_NAME = "github.com/spf13/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git;destsuffix=git/src/${PKG_NAME}"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https;destsuffix=git/src/${PKG_NAME}"
 
 SRCREV = "b5d8e8f46a2f829f755b6e33b454e25c61c935e1"
 PV = "v0.0.1+git${SRCPV}"

--- a/recipes-containers/go-spf13-pflag/spf13-pflag_git.bb
+++ b/recipes-containers/go-spf13-pflag/spf13-pflag_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${PKG_NAME}/LICENSE;md5=1e8b7dc8b906737639131047a
 SRCNAME = "pflag"
 
 PKG_NAME = "github.com/spf13/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git;destsuffix=git/src/${PKG_NAME}"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https;destsuffix=git/src/${PKG_NAME}"
 
 SRCREV = "9ff6c6923cfffbcd502984b8e0c80539a94968b7"
 PV = "v1.0.0-rc4+git${SRCPV}"

--- a/recipes-containers/kubernetes/kubernetes_git.bb
+++ b/recipes-containers/kubernetes/kubernetes_git.bb
@@ -6,7 +6,7 @@ maintenance, and scaling of applications. \
 "
 
 SRCREV_kubernetes = "fc32d2f3698e36b93322a3465f63a14e9f0eaead"
-SRC_URI = "git://github.com/kubernetes/kubernetes.git;nobranch=1;name=kubernetes \
+SRC_URI = "git://github.com/kubernetes/kubernetes.git;nobranch=1;name=kubernetes;protocol=https \
           "
 
 DEPENDS += "rsync-native \

--- a/recipes-containers/oci-image-spec/oci-image-spec_git.bb
+++ b/recipes-containers/oci-image-spec/oci-image-spec_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${PKG_NAME}/LICENSE;md5=27ef03aa2da6e424307f102e8
 SRCNAME = "image-spec"
 
 PKG_NAME = "github.com/opencontainers/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git;destsuffix=git/src/${PKG_NAME}"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https;destsuffix=git/src/${PKG_NAME}"
 
 SRCREV = "91d3eaabebcdc329edd9b4ff0f28f8f90022201f"
 PV = "v1.0.0-rc4+git${SRCPV}"

--- a/recipes-containers/oci-image-tools/oci-image-tools_git.bb
+++ b/recipes-containers/oci-image-tools/oci-image-tools_git.bb
@@ -12,7 +12,7 @@ DEPENDS = "\
            spf13-pflag \
           "
 
-SRC_URI = "git://github.com/opencontainers/image-tools.git \
+SRC_URI = "git://github.com/opencontainers/image-tools.git;protocol=https \
            file://0001-image-manifest-Recursively-remove-pre-existing-entri.patch \
            file://0002-image-manifest-Split-unpackLayerEntry-into-its-own-f.patch \
            file://0001-config-make-Config.User-mapping-errors-a-warning.patch"

--- a/recipes-containers/oci-runtime-spec/oci-runtime-spec_git.bb
+++ b/recipes-containers/oci-runtime-spec/oci-runtime-spec_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${PKG_NAME}/LICENSE;md5=b355a61a394a504dacde901c9
 SRCNAME = "runtime-spec"
 
 PKG_NAME = "github.com/opencontainers/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git;destsuffix=git/src/${PKG_NAME}"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https;destsuffix=git/src/${PKG_NAME}"
 
 SRCREV = "a39b1cd4fdf7743ab721cc9da58abbee2f8624d1"
 PV = "v1.0.0-rc6+git${SRCPV}"

--- a/recipes-containers/oci-runtime-tools/oci-runtime-tools_git.bb
+++ b/recipes-containers/oci-runtime-tools/oci-runtime-tools_git.bb
@@ -3,7 +3,7 @@ SUMMARY = "oci-runtime-tool is a collection of tools for working with the OCI ru
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=b355a61a394a504dacde901c958f662c"
 
-SRC_URI = "git://github.com/opencontainers/runtime-tools.git \
+SRC_URI = "git://github.com/opencontainers/runtime-tools.git;protocol=https \
            file://0001-Revert-implement-add-set-function-for-hooks-items.patch \
            "
 

--- a/recipes-containers/oci-systemd-hook/oci-systemd-hook_git.bb
+++ b/recipes-containers/oci-systemd-hook/oci-systemd-hook_git.bb
@@ -7,7 +7,7 @@ PRIORITY = "optional"
 DEPENDS = "yajl util-linux"
 
 SRCREV = "1ac958a4197a9ea52174812fc7d7d036af8140d3"
-SRC_URI = "git://github.com/projectatomic/oci-systemd-hook \
+SRC_URI = "git://github.com/projectatomic/oci-systemd-hook;protocol=https \
            file://0001-selinux-drop-selinux-support.patch \
            file://0001-configure-drop-selinux-support.patch \
            file://0001-Add-additional-cgroup-mounts-from-root-NS-automatica.patch \

--- a/recipes-containers/riddler/riddler_git.bb
+++ b/recipes-containers/riddler/riddler_git.bb
@@ -3,7 +3,7 @@ SUMMARY = "Convert `docker inspect` to opencontainers (OCI compatible) runc spec
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=20ce4c6a4f32d6ee4a68e3a7506db3f1"
 
-SRC_URI = "git://github.com/jfrazelle/riddler;branch=master"
+SRC_URI = "git://github.com/jfrazelle/riddler;branch=master;protocol=https"
 SRCREV = "23befa0b232877b5b502b828e24161d801bd67f6"
 PV = "0.1.0+git${SRCPV}"
 GO_IMPORT = "import"

--- a/recipes-containers/runc/runc-docker_git.bb
+++ b/recipes-containers/runc/runc-docker_git.bb
@@ -3,7 +3,7 @@ include runc.inc
 # Note: this rev is before the required protocol field, update when all components
 #       have been updated to match.
 SRCREV_runc-docker = "4fc53a81fb7c994640722ac585fa9ca548971871"
-SRC_URI = "git://github.com/opencontainers/runc;nobranch=1;name=runc-docker \
+SRC_URI = "git://github.com/opencontainers/runc;nobranch=1;name=runc-docker;protocol=https \
            file://0001-runc-Add-console-socket-dev-null.patch \
            file://0001-build-drop-recvtty-and-use-GOBUILDFLAGS.patch \
            file://0001-runc-docker-SIGUSR1-daemonize.patch \

--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -2,6 +2,6 @@ include runc.inc
 
 SRCREV = "58415b4b12650291f435db8770cea48207b78afe"
 SRC_URI = " \
-    git://github.com/opencontainers/runc;branch=master \
+    git://github.com/opencontainers/runc;branch=master;protocol=https \
     "
 RUNC_VERSION = "1.0.0-rc5"

--- a/recipes-core/runv/runv_git.bb
+++ b/recipes-core/runv/runv_git.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Hypervisor-based Runtime for OCI"
 
 SRCREV_runv = "b360a686abc6c6e896382990ef1b93ef07c7a677"
 SRC_URI = "\
-	git://github.com/hyperhq/runv.git;nobranch=1;name=runv \
+	git://github.com/hyperhq/runv.git;nobranch=1;name=runv;protocol=https \
 	"
 
 LICENSE = "Apache-2.0"

--- a/recipes-devtools/go/compose-file_git.bb
+++ b/recipes-devtools/go/compose-file_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${PKG_NAME}/LICENSE;md5=9cd86830b557232ce55e2a6b4
 SRCNAME = "compose-file"
 
 PKG_NAME = "github.com/aanand/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git;destsuffix=git/src/${PKG_NAME}"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https;destsuffix=git/src/${PKG_NAME}"
 
 SRCREV = "a3e58764f50597b6217fec07e9bff7225c4a1719"
 PV = "3.0+git${SRCPV}"

--- a/recipes-devtools/go/go-capability_git.bb
+++ b/recipes-devtools/go/go-capability_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=a7304f5073e7be4ba7bffabbf9f2bbca"
 SRCNAME = "gocapability"
 
 PKG_NAME = "github.com/syndtr/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https"
 
 SRCREV = "2c00daeb6c3b45114c80ac44119e7b8801fdd852"
 PV = "0.0+git${SRCPV}"

--- a/recipes-devtools/go/go-cli_git.bb
+++ b/recipes-devtools/go/go-cli_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=ed9b539ed65d73926f30ff1f1587dc44"
 SRCNAME = "cli"
 
 PKG_NAME = "github.com/codegangsta/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https"
 
 SRCREV = "27ecc97192df1bf053a22b04463f2b51b8b8373e"
 PV = "1.1.0+git${SRCREV}"

--- a/recipes-devtools/go/go-connections_git.bb
+++ b/recipes-devtools/go/go-connections_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${PKG_NAME}/LICENSE;md5=04424bc6f5a5be60691b9824d
 SRCNAME = "go-connections"
 
 PKG_NAME = "github.com/docker/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git;destsuffix=git/src/${PKG_NAME}"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https;destsuffix=git/src/${PKG_NAME}"
 
 SRCREV = "4ccf312bf1d35e5dbda654e57a9be4c3f3cd0366"
 PV = "0.2.1+git${SRCPV}"

--- a/recipes-devtools/go/go-context_git.bb
+++ b/recipes-devtools/go/go-context_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c50f6bd9c1e15ed0bad3bea18e3c1b7f"
 SRCNAME = "context"
 
 PKG_NAME = "github.com/gorilla/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https"
 
 SRCREV = "14f550f51af52180c2eefed15e5fd18d63c0a64a"
 

--- a/recipes-devtools/go/go-dbus_git.bb
+++ b/recipes-devtools/go/go-dbus_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=09042bd5c6c96a2b9e45ddf1bc517eed"
 SRCNAME = "dbus"
 
 PKG_NAME = "github.com/godbus/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https"
 
 SRCREV = "5f6efc7ef2759c81b7ba876593971bfce311eab3"
 PV = "4.0.0+git${SRCREV}"

--- a/recipes-devtools/go/go-distribution_git.bb
+++ b/recipes-devtools/go/go-distribution_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${PKG_NAME}/LICENSE;md5=d2794c0df5b907fdace235a61
 SRCNAME = "distribution"
 
 PKG_NAME = "github.com/docker/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git;branch=docker/1.13;destsuffix=git/src/${PKG_NAME}"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https;branch=docker/1.13;destsuffix=git/src/${PKG_NAME}"
 
 SRCREV = "28602af35aceda2f8d571bad7ca37a54cf0250bc"
 PV = "2.6.0+git${SRCPV}"

--- a/recipes-devtools/go/go-fsnotify_git.bb
+++ b/recipes-devtools/go/go-fsnotify_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c38914c9a7ab03bb2b96d4baaee10769"
 SRCNAME = "fsnotify"
 
 PKG_NAME = "github.com/fsnotify/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https"
 
 SRCREV = "836bfd95fecc0f1511dd66bdbf2b5b61ab8b00b6"
 PV = "1.2.11+git${SRCREV}"

--- a/recipes-devtools/go/go-libtrust_git.bb
+++ b/recipes-devtools/go/go-libtrust_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=435b266b3899aa8a959f17d41c56def8"
 SRCNAME = "libtrust"
 
 PKG_NAME = "github.com/docker/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https"
 
 SRCREV = "9cbd2a1374f46905c68a4eb3694a130610adc62a"
 PV = "0.0+git${SRCPV}"

--- a/recipes-devtools/go/go-logrus_git.bb
+++ b/recipes-devtools/go/go-logrus_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=8dadfef729c08ec4e631c4f6fc5d43a0"
 SRCNAME = "logrus"
 
 PKG_NAME = "github.com/Sirupsen/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https"
 
 SRCREV = "d26492970760ca5d33129d2d799e34be5c4782eb"
 PV = "0.11.0+git${SRCREV}"

--- a/recipes-devtools/go/go-mux_git.bb
+++ b/recipes-devtools/go/go-mux_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c50f6bd9c1e15ed0bad3bea18e3c1b7f"
 SRCNAME = "mux"
 
 PKG_NAME = "github.com/gorilla/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https"
 
 SRCREV = "136d54f81f00414c45c3c68dd47e98cc97519c5e"
 

--- a/recipes-devtools/go/go-patricia_git.bb
+++ b/recipes-devtools/go/go-patricia_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=9949b99212edd6b1e24ce702376c3baf"
 SRCNAME = "go-patricia"
 
 PKG_NAME = "github.com/tchap/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https"
 
 SRCREV = "666120de432aea38ab06bd5c818f04f4129882c9"
 PV = "2.2.6+git${SRCPV}"

--- a/recipes-devtools/go/go-pty_git.bb
+++ b/recipes-devtools/go/go-pty_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://License;md5=93958070863d769117fa33b129020050"
 SRCNAME = "pty"
 
 PKG_NAME = "github.com/kr/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https"
 
 SRCREV = "05017fcccf23c823bfdea560dcc958a136e54fb7"
 

--- a/recipes-devtools/go/go-systemd_git.bb
+++ b/recipes-devtools/go/go-systemd_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=19cbd64715b51267a47bf3750cc6a8a5"
 SRCNAME = "systemd"
 
 PKG_NAME = "github.com/coreos/go-${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https"
 
 SRCREV = "b4a58d95188dd092ae20072bac14cece0e67c388"
 PV = "4+git${SRCREV}"

--- a/recipes-devtools/go/grpc-go_git.bb
+++ b/recipes-devtools/go/grpc-go_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${PKG_NAME}/LICENSE;md5=a4bad33881612090c6035d839
 SRCNAME = "grpc-go"
 
 PKG_NAME = "google.golang.org/grpc"
-SRC_URI = "git://github.com/grpc/${SRCNAME}.git;destsuffix=git/src/${PKG_NAME}"
+SRC_URI = "git://github.com/grpc/${SRCNAME}.git;destsuffix=git/src/${PKG_NAME};protocol=https"
 
 SRCREV = "777daa17ff9b5daef1cfdf915088a2ada3332bf0"
 PV = "1.4.0+git${SRCPV}"

--- a/recipes-devtools/go/notary_git.bb
+++ b/recipes-devtools/go/notary_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${PKG_NAME}/LICENSE;md5=771ddb425ba03c8fab49e5bd9
 SRCNAME = "notary"
 
 PKG_NAME = "github.com/docker/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git;destsuffix=git/src/${PKG_NAME}"
+SRC_URI = "git://${PKG_NAME}.git;protocol=https;destsuffix=git/src/${PKG_NAME}"
 
 SRCREV = "c8aa8cf53cbcda2e92def0c9291e25d770493494"
 PV = "0.4.2+git${SRCPV}"

--- a/recipes-extended/diod/diod_1.0.24.bb
+++ b/recipes-extended/diod/diod_1.0.24.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552"
 
 PV = "1.0.24+git${SRCPV}"
 SRCREV = "0ea3fe3d829b5085307cd27a512708d99ef48199"
-SRC_URI = "git://github.com/chaos/diod.git;protocol=git \
+SRC_URI = "git://github.com/chaos/diod.git;protocol=https \
            file://diod \
            file://diod.conf \
            file://0001-build-allow-builds-to-work-with-separate-build-dir.patch \

--- a/recipes-extended/hyperstart/hyperstart_git.bb
+++ b/recipes-extended/hyperstart/hyperstart_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=fa818a259cbed7ce8bc2a22d35a464fc"
 
 inherit autotools-brokensep 
 
-SRC_URI = "git://github.com/hyperhq/hyperstart.git"
+SRC_URI = "git://github.com/hyperhq/hyperstart.git;protocol=https"
 
 SRCREV = "ad48a3230836f59ada163659cde151a37522068b"
 PV = "v0.2+git${SRCREV}"

--- a/recipes-networking/cni/cni_git.bb
+++ b/recipes-networking/cni/cni_git.bb
@@ -12,8 +12,8 @@ is simple to implement. \
 SRCREV_cni = "4b9e11a5266fe50222ed00c5973c6ea4a384a4bb"
 SRCREV_plugins = "c238c93b5e7c681f1935ff813b30e82f96f6c367"
 SRC_URI = "\
-	git://github.com/containernetworking/cni.git;nobranch=1;name=cni \
-        git://github.com/containernetworking/plugins.git;nobranch=1;destsuffix=plugins;name=plugins \
+	git://github.com/containernetworking/cni.git;nobranch=1;name=cni;protocol=https \
+        git://github.com/containernetworking/plugins.git;nobranch=1;destsuffix=plugins;name=plugins;protocol=https \
 	"
 
 RPROVIDES_${PN} += "kubernetes-cni"

--- a/recipes-networking/netns/netns_git.bb
+++ b/recipes-networking/netns/netns_git.bb
@@ -3,7 +3,7 @@ SUMMARY = "Runc hook for setting up default bridge networking."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=48ef0979a2bcc3fae14ff30b8a7f5dbf"
 
-SRC_URI = "git://github.com/genuinetools/netns;branch=master \
+SRC_URI = "git://github.com/genuinetools/netns;branch=master;protocol=https \
            file://0001-Allow-selection-of-go-compiler.patch \
           "
 SRCREV = "0da6ab0997707024debe68c91e940c9168041bf8"

--- a/recipes-networking/openvswitch/openvswitch_git.bb
+++ b/recipes-networking/openvswitch/openvswitch_git.bb
@@ -21,7 +21,7 @@ SRC_URI = "file://openvswitch-switch \
            file://openvswitch-switch-setup \
            file://openvswitch-testcontroller \
            file://openvswitch-testcontroller-setup \
-           git://github.com/openvswitch/ovs.git;protocol=git;branch=branch-2.7 \
+           git://github.com/openvswitch/ovs.git;protocol=https;branch=branch-2.7 \
            file://openvswitch-add-ptest-${SRCREV}.patch \
            file://run-ptest \
            file://disable_m4_check.patch \


### PR DESCRIPTION
Github is moving to deprecate the git protocol in its repos. Update all
github URIs to use the `https` protocol.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

This patchset was partially generated using a backported version of the [`convert-srcuri.py`](https://git.openembedded.org/openembedded-core/tree/scripts/contrib/convert-srcuri.py?id=5e2fc4676b8944fc1d36d567bb2d1ff4cff32294) script that Richard Purdie authored for OE upstream, when the community was mass-converting recipes over to use `protocol=https`. I removed the additional logic from the script to append `branch=master`, because it was more hassle than it was worth. I ran the script against this layer and manually checked the results. The script caught 95% of conversions, and I manually fixed the rest.

# Testing
1. Applied the "warning" commit from [ni/bitbake #6](https://github.com/ni/bitbake/pull/6).
2. Ran `bitbake -n ${targets}` using all the recipe targets which we currently build in the `NIOpenEmbedded` component, and recorded the *many* recipes which failed.
3. Applied this patchset to the meta layer.
4. Cleaned and re-ran bitbake and confirmed that there are now no recipes which warn about using the git protocol with github.

@ni/rtos 