### PR TITLE
convert git://github.com SRC_URIs to use https

### DIFF
--- a/recipes-containers/conmon/conmon_2.0.18.bb
+++ b/recipes-containers/conmon/conmon_2.0.18.bb
@@ -8,7 +8,7 @@ DEPENDS = "glib-2.0 go-md2man-native"
 
 SRCREV = "0e155c83aa739ef0a0540ec9f9d265f57f68038b"
 SRC_URI = "\
-    git://github.com/containers/conmon.git;branch=main \
+    git://github.com/containers/conmon.git;branch=main;protocol=https \
 "
 
 PV = "2.0.26+git${SRCPV}"

--- a/recipes-containers/containerd/containerd-opencontainers_git.bb
+++ b/recipes-containers/containerd/containerd-opencontainers_git.bb
@@ -6,7 +6,7 @@ DESCRIPTION = "containerd is a daemon to control runC, built for performance and
 
 
 SRCREV = "7b11cfaabd73bb80907dd23182b9347b4245eb5d"
-SRC_URI = "git://github.com/containerd/containerd;branch=release/1.4 \
+SRC_URI = "git://github.com/containerd/containerd;branch=release/1.4;protocol=https \
            file://0001-build-use-oe-provided-GO-and-flags.patch \
            file://0001-Add-build-option-GODEBUG-1.patch \
           "

--- a/recipes-containers/cri-o/cri-o_git.bb
+++ b/recipes-containers/cri-o/cri-o_git.bb
@@ -16,7 +16,7 @@ At a high level, we expect the scope of cri-o to be restricted to the following 
 
 SRCREV_cri-o = "7f6ccb579c26519df8cefbf6c9220bd65e25830a"
 SRC_URI = "\
-	git://github.com/kubernetes-sigs/cri-o.git;branch=release-1.21;name=cri-o \
+	git://github.com/kubernetes-sigs/cri-o.git;branch=release-1.21;name=cri-o;protocol=https \
 	file://0001-Makefile-force-symlinks.patch \
         file://crio.conf \
 	"

--- a/recipes-containers/cri-tools/cri-tools_git.bb
+++ b/recipes-containers/cri-tools/cri-tools_git.bb
@@ -18,7 +18,7 @@ What is not in scope for this project? \
 
 SRCREV_cri-tools = "ec9e336fd8c21c4bab89a6aed2c4a138c8cfae75"
 SRC_URI = "\
-	git://github.com/kubernetes-sigs/cri-tools.git;branch=master;name=cri-tools \
+	git://github.com/kubernetes-sigs/cri-tools.git;branch=master;name=cri-tools;protocol=https \
         file://0001-build-allow-environmental-CGO-settings-and-pass-dont.patch \
 	"
 

--- a/recipes-containers/criu/criu_git.bb
+++ b/recipes-containers/criu/criu_git.bb
@@ -16,7 +16,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=412de458544c1cb6a2b512cd399286e2"
 SRCREV = "c703e3fd8404e506cc6156719b953ea0580d59a4"
 PV = "3.13+git${SRCPV}"
 
-SRC_URI = "git://github.com/checkpoint-restore/criu.git \
+SRC_URI = "git://github.com/checkpoint-restore/criu.git;protocol=https \
            file://0001-criu-Fix-toolchain-hardcode.patch \
            file://0002-criu-Skip-documentation-install.patch \
            file://0001-criu-Change-libraries-install-directory.patch \

--- a/recipes-containers/crun/crun_git.bb
+++ b/recipes-containers/crun/crun_git.bb
@@ -10,11 +10,11 @@ SRCREV_rspec = "ab23082b188344f6fbb63a441ea00ffc2852d06d"
 SRCREV_yajl = "f344d21280c3e4094919fd318bc5ce75da91fc06"
 
 SRCREV_FORMAT = "crun_rspec"
-SRC_URI = "git://github.com/containers/crun.git;branch=main;name=crun \
-           git://github.com/containers/libocispec.git;branch=main;name=libocispec;destsuffix=git/libocispec \
-           git://github.com/opencontainers/runtime-spec.git;branch=master;name=rspec;destsuffix=git/libocispec/runtime-spec \
-           git://github.com/opencontainers/image-spec.git;branch=main;name=ispec;destsuffix=git/libocispec/image-spec \
-           git://github.com/containers/yajl.git;branch=main;name=yajl;destsuffix=git/libocispec/yajl \
+SRC_URI = "git://github.com/containers/crun.git;branch=main;name=crun;protocol=https \
+           git://github.com/containers/libocispec.git;branch=main;name=libocispec;destsuffix=git/libocispec;protocol=https \
+           git://github.com/opencontainers/runtime-spec.git;branch=master;name=rspec;destsuffix=git/libocispec/runtime-spec;protocol=https \
+           git://github.com/opencontainers/image-spec.git;branch=main;name=ispec;destsuffix=git/libocispec/image-spec;protocol=https \
+           git://github.com/containers/yajl.git;branch=main;name=yajl;destsuffix=git/libocispec/yajl;protocol=https \
           "
 
 PV = "0.18+git${SRCREV_crun}"

--- a/recipes-containers/docker-distribution/docker-distribution_git.bb
+++ b/recipes-containers/docker-distribution/docker-distribution_git.bb
@@ -4,7 +4,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d2794c0df5b907fdace235a619d80314"
 
 SRCREV_distribution="d7362d7e3a706f3200be70369544094fea3e5b7c"
-SRC_URI = "git://github.com/docker/distribution.git;branch=release/2.7;name=distribution;destsuffix=git/src/github.com/docker/distribution \
+SRC_URI = "git://github.com/docker/distribution.git;branch=release/2.7;name=distribution;destsuffix=git/src/github.com/docker/distribution;protocol=https \
            file://docker-registry.service \
            file://0001-build-use-to-use-cross-go-compiler.patch \
           "

--- a/recipes-containers/docker/docker-ce_git.bb
+++ b/recipes-containers/docker/docker-ce_git.bb
@@ -22,8 +22,8 @@ SRCREV_docker = "99e3ed89195c4e551e87aad1e7453b65456b03ad"
 SRCREV_libnetwork = "55e924b8a84231a065879156c0de95aefc5f5435"
 SRCREV_FORMAT = "docker_libnetwork"
 SRC_URI = "\
-	git://github.com/docker/docker-ce.git;branch=19.03;name=docker \
-	git://github.com/docker/libnetwork.git;branch=bump_19.03;name=libnetwork;destsuffix=git/libnetwork \
+	git://github.com/docker/docker-ce.git;branch=19.03;name=docker;protocol=https \
+	git://github.com/docker/libnetwork.git;branch=bump_19.03;name=libnetwork;destsuffix=git/libnetwork;protocol=https \
 	file://0001-libnetwork-use-GO-instead-of-go.patch \
 	file://docker.init \
 	file://0001-imporve-hardcoded-CC-on-cross-compile-docker-ce.patch \

--- a/recipes-containers/docker/docker-moby.bb
+++ b/recipes-containers/docker/docker-moby.bb
@@ -39,9 +39,9 @@ SRCREV_moby = "11ecfe8a81b7040738333f777681e55e2a867160"
 SRCREV_libnetwork = "b3507428be5b458cb0e2b4086b13531fb0706e46"
 SRCREV_cli = "41b3ea7e472c504c1b7fe8e3347d329ab97b8112"
 SRC_URI = "\
-	git://github.com/moby/moby.git;branch=20.10;name=moby \
-	git://github.com/docker/libnetwork.git;branch=master;name=libnetwork;destsuffix=git/libnetwork \
-	git://github.com/docker/cli;branch=20.10;name=cli;destsuffix=git/cli \
+	git://github.com/moby/moby.git;branch=20.10;name=moby;protocol=https \
+	git://github.com/docker/libnetwork.git;branch=master;name=libnetwork;destsuffix=git/libnetwork;protocol=https \
+	git://github.com/docker/cli;branch=20.10;name=cli;destsuffix=git/cli;protocol=https \
 	file://docker.init \
 	file://0001-libnetwork-use-GO-instead-of-go.patch \
         file://0001-cli-use-go-cross-compiler.patch \

--- a/recipes-containers/k3s/k3s_git.bb
+++ b/recipes-containers/k3s/k3s_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://k3s.io/"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${S}/src/import/LICENSE;md5=2ee41112a44fe7014dce33e26468ba93"
 
-SRC_URI = "git://github.com/rancher/k3s.git;branch=release-1.20;name=k3s \
+SRC_URI = "git://github.com/rancher/k3s.git;branch=release-1.20;name=k3s;protocol=https \
            file://k3s.service \
            file://k3s-agent.service \
            file://k3s-agent \

--- a/recipes-containers/kubernetes/kubernetes_git.bb
+++ b/recipes-containers/kubernetes/kubernetes_git.bb
@@ -1,4 +1,4 @@
-HOMEPAGE = "git://github.com/kubernetes/kubernetes;branch=master"
+HOMEPAGE = "git://github.com/kubernetes/kubernetes;branch=master;protocol=https"
 SUMMARY = "Production-Grade Container Scheduling and Management"
 DESCRIPTION = "Kubernetes is an open source system for managing containerized \
 applications across multiple hosts, providing basic mechanisms for deployment, \
@@ -10,8 +10,8 @@ SRCREV_kubernetes = "7a576bc3935a6b555e33346fd73ad77c925e9e4a"
 SRCREV_kubernetes-release = "cf1e18a801c2ec6cc8c3d3b83bf1cbc4cf0dbc53"
 SRCREV_FORMAT ?= "kubernetes_release"
 
-SRC_URI = "git://github.com/kubernetes/kubernetes.git;branch=release-1.20;name=kubernetes \
-           git://github.com/kubernetes/release;branch=master;name=kubernetes-release;destsuffix=git/release \
+SRC_URI = "git://github.com/kubernetes/kubernetes.git;branch=release-1.20;name=kubernetes;protocol=https \
+           git://github.com/kubernetes/release;branch=master;name=kubernetes-release;destsuffix=git/release;protocol=https \
            file://0001-hack-lib-golang.sh-use-CC-from-environment.patch \
            file://0001-cross-don-t-build-tests-by-default.patch \
            file://0001-generate-bindata-unset-GOBIN.patch \

--- a/recipes-containers/oci-image-spec/oci-image-spec_git.bb
+++ b/recipes-containers/oci-image-spec/oci-image-spec_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${PKG_NAME}/LICENSE;md5=27ef03aa2da6e424307f102e8
 SRCNAME = "image-spec"
 
 PKG_NAME = "github.com/opencontainers/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git;destsuffix=git/src/${PKG_NAME};branch=main"
+SRC_URI = "git://${PKG_NAME}.git;destsuffix=git/src/${PKG_NAME};branch=main;protocol=https"
 
 SRCREV = "bd4f8fcb0979a663d8b97a1d4d9b030b3d2ca1fa"
 PV = "v1.0.1+git${SRCPV}"

--- a/recipes-containers/oci-image-tools/oci-image-tools_git.bb
+++ b/recipes-containers/oci-image-tools/oci-image-tools_git.bb
@@ -12,7 +12,7 @@ DEPENDS = "\
            spf13-pflag \
           "
 
-SRC_URI = "git://github.com/opencontainers/image-tools.git;branch=master \
+SRC_URI = "git://github.com/opencontainers/image-tools.git;branch=master;protocol=https \
            file://0001-config-make-Config.User-mapping-errors-a-warning.patch \
            file://0001-tool-respect-GO-and-GOBUILDFLAGS-when-building.patch"
 

--- a/recipes-containers/oci-runtime-tools/oci-runtime-tools_git.bb
+++ b/recipes-containers/oci-runtime-tools/oci-runtime-tools_git.bb
@@ -3,7 +3,7 @@ SUMMARY = "oci-runtime-tool is a collection of tools for working with the OCI ru
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=b355a61a394a504dacde901c958f662c"
 
-SRC_URI = "git://github.com/opencontainers/runtime-tools.git;branch=master \
+SRC_URI = "git://github.com/opencontainers/runtime-tools.git;branch=master;protocol=https \
            file://0001-Revert-implement-add-set-function-for-hooks-items.patch \
            file://0001-build-use-for-cross-compiler.patch \
            "

--- a/recipes-containers/oci-systemd-hook/oci-systemd-hook_git.bb
+++ b/recipes-containers/oci-systemd-hook/oci-systemd-hook_git.bb
@@ -7,7 +7,7 @@ PRIORITY = "optional"
 DEPENDS = "yajl util-linux"
 
 SRCREV = "05e692346ca73e022754332a7da641230dae2ffe"
-SRC_URI = "git://github.com/projectatomic/oci-systemd-hook;branch=master \
+SRC_URI = "git://github.com/projectatomic/oci-systemd-hook;branch=master;protocol=https \
            file://0001-selinux-drop-selinux-support.patch \
            file://0001-configure-drop-selinux-support.patch \
            file://0001-Add-additional-cgroup-mounts-from-root-NS-automatica.patch \

--- a/recipes-containers/podman-compose/podman-compose_0.1.5.bb
+++ b/recipes-containers/podman-compose/podman-compose_0.1.5.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 inherit setuptools3 pypi
 
-SRC_URI = "git://github.com/containers/podman-compose.git;branch=devel"
+SRC_URI = "git://github.com/containers/podman-compose.git;branch=devel;protocol=https"
 
 SRCREV = "6289d25a42cfdb5dfcac863b1b1b4ace32ce31b7"
 

--- a/recipes-containers/podman/podman_git.bb
+++ b/recipes-containers/podman/podman_git.bb
@@ -18,7 +18,7 @@ PNBLACKLIST[podman] ?= "${@bb.utils.contains('BBFILE_COLLECTIONS', 'security', '
 
 SRCREV = "ab4d0cf908e9d24d321b52b419ebfb4ab5802029"
 SRC_URI = " \
-    git://github.com/containers/libpod.git;branch=v3.2 \
+    git://github.com/containers/libpod.git;branch=v3.2;protocol=https \
 "
 
 LICENSE = "Apache-2.0"

--- a/recipes-containers/riddler/riddler_git.bb
+++ b/recipes-containers/riddler/riddler_git.bb
@@ -3,7 +3,7 @@ SUMMARY = "Convert `docker inspect` to opencontainers (OCI compatible) runc spec
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=20ce4c6a4f32d6ee4a68e3a7506db3f1"
 
-SRC_URI = "git://github.com/jfrazelle/riddler;branch=master \
+SRC_URI = "git://github.com/jfrazelle/riddler;branch=master;protocol=https \
            file://0001-build-use-to-select-cross-compiler.patch \
           "
 

--- a/recipes-containers/runc/runc-docker_git.bb
+++ b/recipes-containers/runc/runc-docker_git.bb
@@ -3,7 +3,7 @@ include runc.inc
 # Note: this rev is before the required protocol field, update when all components
 #       have been updated to match.
 SRCREV_runc-docker = "249bca0a1316129dcd5bd38b5d75572274181cb5"
-SRC_URI = "git://github.com/opencontainers/runc;nobranch=1;name=runc-docker \
+SRC_URI = "git://github.com/opencontainers/runc;nobranch=1;name=runc-docker;protocol=https \
            file://0001-runc-Add-console-socket-dev-null.patch \
            file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
            file://0001-runc-docker-SIGUSR1-daemonize.patch \

--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -2,7 +2,7 @@ include runc.inc
 
 SRCREV = "249bca0a1316129dcd5bd38b5d75572274181cb5"
 SRC_URI = " \
-    git://github.com/opencontainers/runc;branch=main \
+    git://github.com/opencontainers/runc;branch=main;protocol=https \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
     "
 RUNC_VERSION = "1.0.0-rc93"

--- a/recipes-containers/skopeo/skopeo_git.bb
+++ b/recipes-containers/skopeo/skopeo_git.bb
@@ -20,7 +20,7 @@ RDEPENDS_${PN} = " \
 "
 
 SRC_URI = " \
-    git://github.com/containers/skopeo;branch=release-1.2 \
+    git://github.com/containers/skopeo;branch=release-1.2;protocol=https \
     file://storage.conf \
     file://registries.conf \
 "

--- a/recipes-containers/sloci-image/sloci-image-native_git.bb
+++ b/recipes-containers/sloci-image/sloci-image-native_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "A simple CLI tool for packing rootfs into a single-layer OCI image"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=948cd8e59069fad992b0469af9ad7966"
-SRC_URI = "git://github.com/jirutka/sloci-image.git;branch=master \
+SRC_URI = "git://github.com/jirutka/sloci-image.git;branch=master;protocol=https \
            file://0001-sloci-image-fix-variant-quoting.patch \
           "
 

--- a/recipes-containers/tini/tini_0.19.0.bb
+++ b/recipes-containers/tini/tini_0.19.0.bb
@@ -6,7 +6,7 @@ it to exit all the while reaping zombies and performing signal forwarding. "
 
 SRCREV = "b9f42a0e7bb46efea0c9e3d8610c96ab53b467f8"
 SRC_URI = " \
-  git://github.com/krallin/tini.git;branch=master \
+  git://github.com/krallin/tini.git;branch=master;protocol=https \
   file://0001-Do-not-strip-the-output-binary-allow-yocto-to-do-thi.patch \
   "
 

--- a/recipes-core/kata-containers/kata-agent_git.bb
+++ b/recipes-core/kata-containers/kata-agent_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://src/github.com/kata-containers/agent/LICENSE;md5=86d3
 
 GO_IMPORT = "github.com/kata-containers/agent"
 SRCREV = "e03f7d7453fabffb17e1540f28666c26178d3cbf"
-SRC_URI = "git://${GO_IMPORT}.git;branch=master \
+SRC_URI = "git://${GO_IMPORT}.git;branch=master;protocol=https \
           "
 
 RDEPENDS_${PN}-dev_append = "bash"

--- a/recipes-core/kata-containers/kata-proxy_git.bb
+++ b/recipes-core/kata-containers/kata-proxy_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://src/github.com/kata-containers/proxy/LICENSE;md5=86d3
 
 GO_IMPORT = "github.com/kata-containers/proxy"
 SRCREV = "1148847739f9a9f47b92e34e4f309dc109d4dba9"
-SRC_URI = "git://${GO_IMPORT}.git;branch=master \
+SRC_URI = "git://${GO_IMPORT}.git;branch=master;protocol=https \
           "
 
 RDEPENDS_${PN}-dev_append = "bash"

--- a/recipes-core/kata-containers/kata-runtime_git.bb
+++ b/recipes-core/kata-containers/kata-runtime_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://src/github.com/kata-containers/runtime/LICENSE;md5=86
 
 GO_IMPORT = "github.com/kata-containers/runtime"
 SRCREV = "04c77eb20e9bd603cab5c711bcbe7c69db58b040"
-SRC_URI = "git://${GO_IMPORT}.git;branch=master \
+SRC_URI = "git://${GO_IMPORT}.git;branch=master;protocol=https \
            file://0001-makefile-allow-SKIP_GO_VERSION_CHECK-to-be-overriden.patch \
           "
 RDEPENDS_${PN}-dev_append = "bash"

--- a/recipes-core/kata-containers/kata-shim_git.bb
+++ b/recipes-core/kata-containers/kata-shim_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://src/github.com/kata-containers/shim/LICENSE;md5=86d3f
 
 GO_IMPORT = "github.com/kata-containers/shim"
 SRCREV = "bcc35aeca3ef6fa0976005c9e93525906aefed2f"
-SRC_URI = "git://${GO_IMPORT}.git;branch=master \
+SRC_URI = "git://${GO_IMPORT}.git;branch=master;protocol=https \
           "
 
 RDEPENDS_${PN}-dev_append = "bash"

--- a/recipes-core/runv/runv_git.bb
+++ b/recipes-core/runv/runv_git.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Hypervisor-based Runtime for OCI"
 
 SRCREV_runv = "b360a686abc6c6e896382990ef1b93ef07c7a677"
 SRC_URI = "\
-	git://github.com/hyperhq/runv.git;nobranch=1;name=runv \
+	git://github.com/hyperhq/runv.git;nobranch=1;name=runv;protocol=https \
 	"
 
 LICENSE = "Apache-2.0"

--- a/recipes-core/runx/runx_git.bb
+++ b/recipes-core/runx/runx_git.bb
@@ -8,7 +8,7 @@ KERNEL_SRC_VER="linux-5.4"
 KERNEL_URL_VER="v5.x"
 
 SRC_URI = "\
-	  git://github.com/lf-edge/runx;nobranch=1;name=runx \
+	  git://github.com/lf-edge/runx;nobranch=1;name=runx;protocol=https \
           https://www.kernel.org/pub/linux/kernel/${KERNEL_URL_VER}/${KERNEL_SRC_VER}.tar.xz;destsuffix=git/kernel/build \
           file://0001-make-kernel-cross-compilation-tweaks.patch \
           file://0001-make-kernel-bump-to-v5.4.104-for-gcc10-fixes.patch \

--- a/recipes-devtools/go/go-build_git.bb
+++ b/recipes-devtools/go/go-build_git.bb
@@ -5,7 +5,7 @@ DESCRIPTION = "Xen Runtime for OCI"
 SRCREV_runx = "f24efd33fb18469e9cfe4d1bfe8e2c90ec8c4e93"
 
 SRC_URI = "\
-	  git://github.com/lf-edge/runx;nobranch=1;name=runx \
+	  git://github.com/lf-edge/runx;nobranch=1;name=runx;protocol=https \
           file://0001-build-use-instead-of-go.patch \
 	  "
 SRC_URI[md5sum] = "0d701ac1e2a67d47ce7127432df2c32b"

--- a/recipes-devtools/go/go-distribution_git.bb
+++ b/recipes-devtools/go/go-distribution_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${PKG_NAME}/LICENSE;md5=d2794c0df5b907fdace235a61
 SRCNAME = "distribution"
 
 PKG_NAME = "github.com/docker/${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git;branch=docker/1.13;destsuffix=git/src/${PKG_NAME}"
+SRC_URI = "git://${PKG_NAME}.git;branch=docker/1.13;destsuffix=git/src/${PKG_NAME};protocol=https"
 
 SRCREV = "28602af35aceda2f8d571bad7ca37a54cf0250bc"
 PV = "2.6.0+git${SRCPV}"

--- a/recipes-devtools/go/go-md2man_git.bb
+++ b/recipes-devtools/go/go-md2man_git.bb
@@ -9,7 +9,7 @@ BBCLASSEXTEND = "native"
 GO_IMPORT = "github.com/cpuguy83/go-md2man"
 #GO_INSTALL = "${GO_IMPORT}/bin/go-md2man"
 
-SRC_URI = "git://${GO_IMPORT}.git;branch=master"
+SRC_URI = "git://${GO_IMPORT}.git;branch=master;protocol=https"
 
 SRCREV = "f79a8a8ca69da163eee19ab442bedad7a35bba5a"
 PV = "1.0.10+git${SRCPV}"

--- a/recipes-devtools/go/go-systemd_git.bb
+++ b/recipes-devtools/go/go-systemd_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=19cbd64715b51267a47bf3750cc6a8a5"
 SRCNAME = "systemd"
 
 PKG_NAME = "github.com/coreos/go-${SRCNAME}"
-SRC_URI = "git://${PKG_NAME}.git;branch=main"
+SRC_URI = "git://${PKG_NAME}.git;branch=main;protocol=https"
 
 SRCREV = "b4a58d95188dd092ae20072bac14cece0e67c388"
 PV = "4+git${SRCPV}"

--- a/recipes-devtools/go/grpc-go_git.bb
+++ b/recipes-devtools/go/grpc-go_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${PKG_NAME}/LICENSE;md5=a4bad33881612090c6035d839
 SRCNAME = "grpc-go"
 
 PKG_NAME = "google.golang.org/grpc"
-SRC_URI = "git://github.com/grpc/${SRCNAME}.git;destsuffix=git/src/${PKG_NAME};branch=master"
+SRC_URI = "git://github.com/grpc/${SRCNAME}.git;destsuffix=git/src/${PKG_NAME};branch=master;protocol=https"
 
 SRCREV = "777daa17ff9b5daef1cfdf915088a2ada3332bf0"
 PV = "1.4.0+git${SRCPV}"

--- a/recipes-devtools/yq/yq_git.bb
+++ b/recipes-devtools/yq/yq_git.bb
@@ -15,15 +15,15 @@ SRCREV_logging = "b2cb9fa56473e98db8caba80237377e83fe44db5"
 SRCREV_yaml = "eeeca48fe7764f320e4870d231902bf9c1be2c08"
 
 SRCREV_FORMAT = "yq_color"
-SRC_URI = "git://${GO_IMPORT};name=yq;branch=master \
-           git://github.com/fatih/color;name=color;destsuffix=build/vendor/src/github.com/fatih/color;branch=master \
-           git://github.com/goccy/go-yaml;name=lexer;destsuffix=build/vendor/src/github.com/goccy/go-yaml/;branch=master \
-           git://github.com/kylelemons/godebug;name=debug;destsuffix=build/vendor/src/github.com/kylelemons/godebug/;branch=master \
-	   git://github.com/pkg/errors;name=errors;destsuffix=build/vendor/src/github.com/pkg/errors/;branch=master \
-	   git://github.com/spf13/cobra;name=cobra;destsuffix=build/vendor/src/github.com/spf13/cobra;branch=master \
-	   git://github.com/spf13/pflag;name=pflag;destsuffix=build/vendor/src/github.com/spf13/pflag;branch=master \
-	   git://github.com/op/go-logging.git;name=logging;destsuffix=build/vendor/src/gopkg.in/op/go-logging.v1;branch=master \
-	   git://github.com/go-yaml/yaml.git;name=yaml;branch=v3;destsuffix=build/vendor/src/gopkg.in/yaml.v3 \
+SRC_URI = "git://${GO_IMPORT};name=yq;branch=master;protocol=https \
+           git://github.com/fatih/color;name=color;destsuffix=build/vendor/src/github.com/fatih/color;branch=master;protocol=https \
+           git://github.com/goccy/go-yaml;name=lexer;destsuffix=build/vendor/src/github.com/goccy/go-yaml/;branch=master;protocol=https \
+           git://github.com/kylelemons/godebug;name=debug;destsuffix=build/vendor/src/github.com/kylelemons/godebug/;branch=master;protocol=https \
+	   git://github.com/pkg/errors;name=errors;destsuffix=build/vendor/src/github.com/pkg/errors/;branch=master;protocol=https \
+	   git://github.com/spf13/cobra;name=cobra;destsuffix=build/vendor/src/github.com/spf13/cobra;branch=master;protocol=https \
+	   git://github.com/spf13/pflag;name=pflag;destsuffix=build/vendor/src/github.com/spf13/pflag;branch=master;protocol=https \
+	   git://github.com/op/go-logging.git;name=logging;destsuffix=build/vendor/src/gopkg.in/op/go-logging.v1;branch=master;protocol=https \
+	   git://github.com/go-yaml/yaml.git;name=yaml;branch=v3;destsuffix=build/vendor/src/gopkg.in/yaml.v3;protocol=https \
            "
 
 PV = "1.13.1+git${SRCREV_yq}"

--- a/recipes-extended/diod/diod_1.0.24.bb
+++ b/recipes-extended/diod/diod_1.0.24.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552"
 
 PV = "1.0.24+git${SRCPV}"
 SRCREV = "0ea3fe3d829b5085307cd27a512708d99ef48199"
-SRC_URI = "git://github.com/chaos/diod.git;protocol=git;branch=master \
+SRC_URI = "git://github.com/chaos/diod.git;protocol=https;branch=master \
            file://diod \
            file://diod.conf \
            file://0001-build-allow-builds-to-work-with-separate-build-dir.patch \

--- a/recipes-extended/fuse-overlayfs/fuse-overlayfs_0.6.4.bb
+++ b/recipes-extended/fuse-overlayfs/fuse-overlayfs_0.6.4.bb
@@ -6,7 +6,7 @@ LICENSE = "GPLv3+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
 SRCREV = "098d9ad79fdbb8538adde08628408aa32a8b4b17"
-SRC_URI = "git://github.com/containers/fuse-overlayfs.git;nobranch=1"
+SRC_URI = "git://github.com/containers/fuse-overlayfs.git;nobranch=1;protocol=https"
 
 DEPENDS = "fuse3"
 

--- a/recipes-extended/hyperstart/hyperstart_git.bb
+++ b/recipes-extended/hyperstart/hyperstart_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=fa818a259cbed7ce8bc2a22d35a464fc"
 
 inherit autotools-brokensep 
 
-SRC_URI = "git://github.com/hyperhq/hyperstart.git;branch=master"
+SRC_URI = "git://github.com/hyperhq/hyperstart.git;branch=master;protocol=https"
 SRC_URI += "file://0001-container.c-Fix-compiler-errors-that-gcc-8.1.0-repor.patch"
 
 SRCREV = "c0c07d218b482dd07f9068b52a6e7468ae4172ac"

--- a/recipes-extended/irqbalance/irqbalance_git.bb
+++ b/recipes-extended/irqbalance/irqbalance_git.bb
@@ -9,7 +9,7 @@ require irqbalance.inc
 SRCREV = "641edc6f5d56f1b3eb8be0fa8a8e9b6a22e53218"
 PV = "1.7.0"
 
-SRC_URI = "git://github.com/Irqbalance/irqbalance;branch=master \
+SRC_URI = "git://github.com/Irqbalance/irqbalance;branch=master;protocol=https \
            file://add-initscript.patch \
            file://irqbalance-Add-status-and-reload-commands.patch \
            file://irqbalanced.service \

--- a/recipes-extended/libvmi/libvmi_git.bb
+++ b/recipes-extended/libvmi/libvmi_git.bb
@@ -8,7 +8,7 @@ PV = "0.12.0"
 
 DEPENDS = "libvirt libcheck bison fuse byacc-native"
 
-SRC_URI = "git://github.com/libvmi/libvmi.git;branch=master \
+SRC_URI = "git://github.com/libvmi/libvmi.git;branch=master;protocol=https \
 "
 
 SRCREV = "e8c2061d11c42e5868cbf48229f59b5e7071395a"

--- a/recipes-extended/upx/upx_git.bb
+++ b/recipes-extended/upx/upx_git.bb
@@ -2,7 +2,7 @@ HOMEPAGE = "http://upx.sourceforge.net"
 SUMMARY = "Ultimate executable compressor."
 
 SRCREV = "4e1ae22a1a07be5135c68b25ff05058ae8ae48e1"
-SRC_URI = "gitsm://github.com/upx/upx;branch=devel"
+SRC_URI = "gitsm://github.com/upx/upx;branch=devel;protocol=https"
 
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=353753597aa110e0ded3508408c6374a"

--- a/recipes-networking/cni/cni_git.bb
+++ b/recipes-networking/cni/cni_git.bb
@@ -13,8 +13,8 @@ SRCREV_cni = "b5ab16f010e822936eb974690ecec38ba69afc01"
 # Version 0.8.5
 SRCREV_plugins = "fa48f7515b50272b7106702a662fadbf2ead3d18"
 SRC_URI = "\
-	git://github.com/containernetworking/cni.git;nobranch=1;name=cni \
-        git://github.com/containernetworking/plugins.git;nobranch=1;destsuffix=${S}/src/github.com/containernetworking/plugins;name=plugins \
+	git://github.com/containernetworking/cni.git;nobranch=1;name=cni;protocol=https \
+        git://github.com/containernetworking/plugins.git;nobranch=1;destsuffix=${S}/src/github.com/containernetworking/plugins;name=plugins;protocol=https \
 	"
 SRCREV_FORMAT = "cni_plugins"
 

--- a/recipes-networking/netns/netns_git.bb
+++ b/recipes-networking/netns/netns_git.bb
@@ -3,7 +3,7 @@ SUMMARY = "Runc hook for setting up default bridge networking."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=48ef0979a2bcc3fae14ff30b8a7f5dbf"
 
-SRC_URI = "git://github.com/genuinetools/netns;branch=master \
+SRC_URI = "git://github.com/genuinetools/netns;branch=master;protocol=https \
            file://Makefile-force-rebuilding-all-packages-to-avoid-cgo.patch \
           "
 SRCREV = "9b103a19b917cc3762a33b7d78244b1d5e45ccfd"

--- a/recipes-networking/openvswitch/openvswitch_git.bb
+++ b/recipes-networking/openvswitch/openvswitch_git.bb
@@ -20,7 +20,7 @@ CVE_VERSION = "2.13.0"
 FILESEXTRAPATHS_append := "${THISDIR}/${PN}-git:"
 
 SRCREV = "8dc1733eaea866dce033b3c44853e1b09bf59fc7"
-SRC_URI += "git://github.com/openvswitch/ovs.git;protocol=git;branch=branch-2.15 \
+SRC_URI += "git://github.com/openvswitch/ovs.git;protocol=https;branch=branch-2.15 \
             file://openvswitch-add-ptest-71d553b995d0bd527d3ab1e9fbaf5a2ae34de2f3.patch \
             file://run-ptest \
             file://disable_m4_check.patch \

--- a/recipes-networking/slirp4netns/slirp4netns_0.4.1.bb
+++ b/recipes-networking/slirp4netns/slirp4netns_0.4.1.bb
@@ -7,7 +7,7 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=1e2efd29c201480c6be2744d9edade26"
 
 SRCREV = "4d38845e2e311b684fc8d1c775c725bfcd5ddc27"
-SRC_URI = "git://github.com/rootless-containers/slirp4netns.git;nobranch=1"
+SRC_URI = "git://github.com/rootless-containers/slirp4netns.git;nobranch=1;protocol=https"
 
 DEPENDS = "glib-2.0 libcap libseccomp"
 


### PR DESCRIPTION
Github is moving to deprecate the git:// protocol for repo access. Use a
modified version of the upstream covert-srcuris.py script to find and
fixup github source URIs in-bulk.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

# Testing
Ran the `do_fetch` tasks of `packagefeed-ni-core` and confirmed that bitbake does not report any recipes as using a `git://github.com` URI.

@ni/rtos