### PR TITLE
meta-virtualization: Currency merge with upstream kirkstone branch

### DIFF
--- a/recipes-extended/upx/upx_git.bb
+++ b/recipes-extended/upx/upx_git.bb
@@ -1,45 +1,16 @@
-HOMEPAGE = "http://upx.sourceforge.net"
 SUMMARY = "Ultimate executable compressor."
-
-SRCREV_upx = "8d1a98e03bf281b2cee459b6c27347e56d13c6a8"
-SRCREV_vendor_doctest = "666e648b68fda2deb141a1fe93e3fd1e2795dd0f"
-SRCREV_vendor_lzma_sdk = "9ebf8f468c689d83504e6c08c6bc26c4a1cf180f"
-SRCREV_vendor_ucl = "4b58d592199dc1e5db691e1a54fb0e5e9af0ecaf"
-SRCREV_vendor_zlib = "2a5b338eb173a701ed179e951d4c390e75e8d4c7"
-SRCREV_FORMAT = "upx"
-SRC_URI = "git://github.com/upx/upx;name=upx;branch=devel;protocol=https \
-           git://github.com/upx/upx-vendor-doctest;name=vendor_doctest;subdir=git/vendor/doctest;branch=upx-vendor;protocol=https \
-           git://github.com/upx/upx-vendor-lzma-sdk;name=vendor_lzma_sdk;subdir=git/vendor/lzma-sdk;branch=upx-vendor;protocol=https \
-           git://github.com/upx/upx-vendor-ucl;name=vendor_ucl;subdir=git/vendor/ucl;branch=upx-vendor;protocol=https \
-           git://github.com/upx/upx-vendor-zlib;name=vendor_zlib;subdir=git/vendor/zlib;branch=upx-vendor;protocol=https \
-"
-
+HOMEPAGE = "* https://upx.github.io/"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=353753597aa110e0ded3508408c6374a"
+SRCREV_upx = "099c3d829e80488af7395a4242b318877e980da4"
+PV = "4.2.2+git${SRCPV}"
 
-DEPENDS = "zlib libucl xz cmake-native"
-
-# inherit cmake
+# Note: DO NOT use released tarball in favor of the git repository with submodules.
+# it makes maintenance easier for CVEs or other issues.
+SRC_URI = "gitsm://github.com/upx/upx;protocol=https;;name=upx;branch=devel"
 
 S = "${WORKDIR}/git"
 
-PV = "3.96+${SRCPV}"
-
-EXTRA_OEMAKE += " \
-    UPX_UCLDIR=${STAGING_DIR_TARGET} \
-    UPX_LZMADIR=${STAGING_DIR_TARGET} \
-"
-
-# FIXME: The build fails if security flags are enabled
-SECURITY_CFLAGS = ""
-
-do_compile() {
-    oe_runmake -C src all
-}
-
-do_install:append() {
-    install -d ${D}${bindir}
-    install -m 755 ${B}/build/release/upx ${D}${bindir}/upx
-}
+inherit pkgconfig cmake
 
 BBCLASSEXTEND = "native"


### PR DESCRIPTION
This is the 2024Q1.3 currency merge with upstream kirkstone branch.
There were no merge conflicts and no additional NI-specific patches are required.

[AB#2581841](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2581841)

### Testing

- [x] bitbake packagefeed-ni-core
- [x] bitbake packagegroup-ni-desirable
- [x] bitbake package-index && bitbake nilrt-base-system-image
- [x] unpacked resulting `nilrt-base-system-image-x64.tar` on a freshly formatted cRIO-9043 and verified the target boots into runmode w/o problems.

### Notes

- maintainers please complete this merge manually (i.e. to avoid upstream hashes being changed by GH).