### PR TITLE
runc-opencontainers: fix CVE-2024-21626​ possible container escape

### DIFF
--- a/recipes-containers/runc/files/0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch
+++ b/recipes-containers/runc/files/0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch
@@ -15,12 +15,12 @@ Index: git/src/import/Makefile
 ===================================================================
 --- git.orig/src/import/Makefile
 +++ git/src/import/Makefile
-@@ -20,7 +20,7 @@
- 		endif
+@@ -24,7 +24,7 @@
+ 		GO_BUILDMODE := "-buildmode=pie"
  	endif
  endif
--GO_BUILD := $(GO) build -trimpath $(GO_BUILDMODE) $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
-+GO_BUILD := $(GO) build $(GOBUILDFLAGS) -trimpath $(GO_BUILDMODE) $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
- 	-ldflags "-X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
- GO_BUILD_STATIC := CGO_ENABLED=1 $(GO) build -trimpath $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo" \
- 	-ldflags "-extldflags -static -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
+-GO_BUILD := $(GO) build -trimpath $(GO_BUILDMODE) \
++GO_BUILD := $(GO) build $(GOBUILDFLAGS) -trimpath $(GO_BUILDMODE) \
+ 	$(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
+ 	-ldflags "$(LDFLAGS_COMMON) $(EXTRA_LDFLAGS)"
+ 

--- a/recipes-containers/runc/runc-docker_git.bb
+++ b/recipes-containers/runc/runc-docker_git.bb
@@ -2,7 +2,7 @@ include runc.inc
 
 # Note: this rev is before the required protocol field, update when all components
 #       have been updated to match.
-SRCREV_runc-docker = "974efd2dfca0abec041a3708a2b66bfac6bd2484"
+SRCREV_runc-docker = "bd4d05c0caf340f2d1fd1625f5c1129ce01c97b5"
 SRC_URI = "git://github.com/opencontainers/runc;branch=release-1.1;name=runc-docker;protocol=https \
            file://0001-runc-Add-console-socket-dev-null.patch \
            file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \

--- a/recipes-containers/runc/runc-docker_git.bb
+++ b/recipes-containers/runc/runc-docker_git.bb
@@ -2,7 +2,7 @@ include runc.inc
 
 # Note: this rev is before the required protocol field, update when all components
 #       have been updated to match.
-SRCREV_runc-docker = "26a98ea20ee1e946f07fc8a9ba9f11b84b39e4a0"
+SRCREV_runc-docker = "452f520c1023a2d4a201cc3f19ffa37e09fa1f0b"
 SRC_URI = "git://github.com/opencontainers/runc;branch=release-1.1;name=runc-docker;protocol=https \
            file://0001-runc-Add-console-socket-dev-null.patch \
            file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \

--- a/recipes-containers/runc/runc-docker_git.bb
+++ b/recipes-containers/runc/runc-docker_git.bb
@@ -2,13 +2,13 @@ include runc.inc
 
 # Note: this rev is before the required protocol field, update when all components
 #       have been updated to match.
-SRCREV_runc-docker = "aa68c400a89db049e57d33c53cf14c5152066de4"
+SRCREV_runc-docker = "26a98ea20ee1e946f07fc8a9ba9f11b84b39e4a0"
 SRC_URI = "git://github.com/opencontainers/runc;branch=release-1.1;name=runc-docker;protocol=https \
            file://0001-runc-Add-console-socket-dev-null.patch \
            file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
            file://0001-runc-docker-SIGUSR1-daemonize.patch \
           "
 
-RUNC_VERSION = "1.1.8"
+RUNC_VERSION = "1.1.9"
 
 CVE_PRODUCT = "runc"

--- a/recipes-containers/runc/runc-docker_git.bb
+++ b/recipes-containers/runc/runc-docker_git.bb
@@ -2,13 +2,13 @@ include runc.inc
 
 # Note: this rev is before the required protocol field, update when all components
 #       have been updated to match.
-SRCREV_runc-docker = "ca73c9fd4b684a7ddec8b3bd892b5f76d6f21710"
+SRCREV_runc-docker = "aa68c400a89db049e57d33c53cf14c5152066de4"
 SRC_URI = "git://github.com/opencontainers/runc;branch=release-1.1;name=runc-docker;protocol=https \
            file://0001-runc-Add-console-socket-dev-null.patch \
            file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
            file://0001-runc-docker-SIGUSR1-daemonize.patch \
           "
 
-RUNC_VERSION = "1.1.7"
+RUNC_VERSION = "1.1.8"
 
 CVE_PRODUCT = "runc"

--- a/recipes-containers/runc/runc-docker_git.bb
+++ b/recipes-containers/runc/runc-docker_git.bb
@@ -2,13 +2,13 @@ include runc.inc
 
 # Note: this rev is before the required protocol field, update when all components
 #       have been updated to match.
-SRCREV_runc-docker = "17a2d451d635e5eda2e4902324428f1bc65b0364"
+SRCREV_runc-docker = "b6109acd4d81e8a33dd07d94e6a7f9c706d8356c"
 SRC_URI = "git://github.com/opencontainers/runc;branch=release-1.1;name=runc-docker;protocol=https \
            file://0001-runc-Add-console-socket-dev-null.patch \
            file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
            file://0001-runc-docker-SIGUSR1-daemonize.patch \
           "
 
-RUNC_VERSION = "1.1.5"
+RUNC_VERSION = "1.1.7"
 
 CVE_PRODUCT = "runc"

--- a/recipes-containers/runc/runc-docker_git.bb
+++ b/recipes-containers/runc/runc-docker_git.bb
@@ -2,7 +2,7 @@ include runc.inc
 
 # Note: this rev is before the required protocol field, update when all components
 #       have been updated to match.
-SRCREV_runc-docker = "b6109acd4d81e8a33dd07d94e6a7f9c706d8356c"
+SRCREV_runc-docker = "ca73c9fd4b684a7ddec8b3bd892b5f76d6f21710"
 SRC_URI = "git://github.com/opencontainers/runc;branch=release-1.1;name=runc-docker;protocol=https \
            file://0001-runc-Add-console-socket-dev-null.patch \
            file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \

--- a/recipes-containers/runc/runc-docker_git.bb
+++ b/recipes-containers/runc/runc-docker_git.bb
@@ -2,13 +2,13 @@ include runc.inc
 
 # Note: this rev is before the required protocol field, update when all components
 #       have been updated to match.
-SRCREV_runc-docker = "c6781d100a73d2dcef84e9376d85fff02235a2ed"
+SRCREV_runc-docker = "17a2d451d635e5eda2e4902324428f1bc65b0364"
 SRC_URI = "git://github.com/opencontainers/runc;branch=release-1.1;name=runc-docker;protocol=https \
            file://0001-runc-Add-console-socket-dev-null.patch \
            file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
            file://0001-runc-docker-SIGUSR1-daemonize.patch \
           "
 
-RUNC_VERSION = "1.1.4"
+RUNC_VERSION = "1.1.5"
 
 CVE_PRODUCT = "runc"

--- a/recipes-containers/runc/runc-docker_git.bb
+++ b/recipes-containers/runc/runc-docker_git.bb
@@ -2,7 +2,7 @@ include runc.inc
 
 # Note: this rev is before the required protocol field, update when all components
 #       have been updated to match.
-SRCREV_runc-docker = "bd4d05c0caf340f2d1fd1625f5c1129ce01c97b5"
+SRCREV_runc-docker = "c6781d100a73d2dcef84e9376d85fff02235a2ed"
 SRC_URI = "git://github.com/opencontainers/runc;branch=release-1.1;name=runc-docker;protocol=https \
            file://0001-runc-Add-console-socket-dev-null.patch \
            file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \

--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -1,6 +1,6 @@
 include runc.inc
 
-SRCREV = "974efd2dfca0abec041a3708a2b66bfac6bd2484"
+SRCREV = "bd4d05c0caf340f2d1fd1625f5c1129ce01c97b5"
 SRC_URI = " \
     git://github.com/opencontainers/runc;branch=release-1.1;protocol=https \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \

--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -1,11 +1,11 @@
 include runc.inc
 
-SRCREV = "f3446b1e5fe75bf419c808d8705c899ab4968b6e"
+SRCREV = "452f520c1023a2d4a201cc3f19ffa37e09fa1f0b"
 SRC_URI = " \
     git://github.com/opencontainers/runc;branch=release-1.1;protocol=https \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
     "
-RUNC_VERSION = "1.1.10"
+RUNC_VERSION = "1.1.11"
 
 CVE_PRODUCT = "runc"
 

--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -1,11 +1,11 @@
 include runc.inc
 
-SRCREV = "452f520c1023a2d4a201cc3f19ffa37e09fa1f0b"
+SRCREV = "a9833ff391a71b30069a6c3f816db113379a4346"
 SRC_URI = " \
     git://github.com/opencontainers/runc;branch=release-1.1;protocol=https \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
     "
-RUNC_VERSION = "1.1.11"
+RUNC_VERSION = "1.1.12"
 
 CVE_PRODUCT = "runc"
 

--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -1,11 +1,11 @@
 include runc.inc
 
-SRCREV = "aa68c400a89db049e57d33c53cf14c5152066de4"
+SRCREV = "26a98ea20ee1e946f07fc8a9ba9f11b84b39e4a0"
 SRC_URI = " \
     git://github.com/opencontainers/runc;branch=release-1.1;protocol=https \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
     "
-RUNC_VERSION = "1.1.8"
+RUNC_VERSION = "1.1.9"
 
 CVE_PRODUCT = "runc"
 

--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -1,10 +1,10 @@
 include runc.inc
 
-SRCREV = "17a2d451d635e5eda2e4902324428f1bc65b0364"
+SRCREV = "b6109acd4d81e8a33dd07d94e6a7f9c706d8356c"
 SRC_URI = " \
     git://github.com/opencontainers/runc;branch=release-1.1;protocol=https \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
     "
-RUNC_VERSION = "1.1.5"
+RUNC_VERSION = "1.1.7"
 
 CVE_PRODUCT = "runc"

--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -1,6 +1,6 @@
 include runc.inc
 
-SRCREV = "bd4d05c0caf340f2d1fd1625f5c1129ce01c97b5"
+SRCREV = "c6781d100a73d2dcef84e9376d85fff02235a2ed"
 SRC_URI = " \
     git://github.com/opencontainers/runc;branch=release-1.1;protocol=https \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \

--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -1,11 +1,11 @@
 include runc.inc
 
-SRCREV = "ca73c9fd4b684a7ddec8b3bd892b5f76d6f21710"
+SRCREV = "aa68c400a89db049e57d33c53cf14c5152066de4"
 SRC_URI = " \
     git://github.com/opencontainers/runc;branch=release-1.1;protocol=https \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
     "
-RUNC_VERSION = "1.1.7"
+RUNC_VERSION = "1.1.8"
 
 CVE_PRODUCT = "runc"
 

--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -8,3 +8,5 @@ SRC_URI = " \
 RUNC_VERSION = "1.1.7"
 
 CVE_PRODUCT = "runc"
+
+LDFLAGS += "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', ' -fuse-ld=bfd', '', d)}"

--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -1,6 +1,6 @@
 include runc.inc
 
-SRCREV = "b6109acd4d81e8a33dd07d94e6a7f9c706d8356c"
+SRCREV = "ca73c9fd4b684a7ddec8b3bd892b5f76d6f21710"
 SRC_URI = " \
     git://github.com/opencontainers/runc;branch=release-1.1;protocol=https \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \

--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -1,11 +1,11 @@
 include runc.inc
 
-SRCREV = "26a98ea20ee1e946f07fc8a9ba9f11b84b39e4a0"
+SRCREV = "f3446b1e5fe75bf419c808d8705c899ab4968b6e"
 SRC_URI = " \
     git://github.com/opencontainers/runc;branch=release-1.1;protocol=https \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
     "
-RUNC_VERSION = "1.1.9"
+RUNC_VERSION = "1.1.10"
 
 CVE_PRODUCT = "runc"
 

--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -1,10 +1,10 @@
 include runc.inc
 
-SRCREV = "c6781d100a73d2dcef84e9376d85fff02235a2ed"
+SRCREV = "17a2d451d635e5eda2e4902324428f1bc65b0364"
 SRC_URI = " \
     git://github.com/opencontainers/runc;branch=release-1.1;protocol=https \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
     "
-RUNC_VERSION = "1.1.4"
+RUNC_VERSION = "1.1.5"
 
 CVE_PRODUCT = "runc"


### PR DESCRIPTION
This patchset cherry-picks an upgrade for runc-opencontainers https://nvd.nist.gov/vuln/detail/CVE-2024-21626 from the upstream master-next branch of meta-virtualization.  Several dependent commits are included, primarly updates to intervening versions.

[AB#2678841](https://ni.visualstudio.com/DevCentral/_workitems/edit/2678841)

### Testing
- [X] Sanity tests run with a couple of containers
- [X] CVE shows as patched now in the CVE report.

### Meta
This needs to be cherry-picked to nilrt/master/next also.