### PR TITLE
meta-virtualization: Regular NILRT distro upstream merge

### DIFF
--- a/recipes-networking/openvswitch/openvswitch_git.bb
+++ b/recipes-networking/openvswitch/openvswitch_git.bb
@@ -14,12 +14,12 @@ RDEPENDS:${PN}-ptest += "\
 	"
 
 S = "${WORKDIR}/git"
-PV = "2.17.6+${SRCPV}"
-CVE_VERSION = "2.17.6"
+PV = "2.17.9+${SRCPV}"
+CVE_VERSION = "2.17.9"
 
 FILESEXTRAPATHS:append := "${THISDIR}/${PN}-git:"
 
-SRCREV = "a08bb41e3c381f695b5ab62b0ab49b39c2b98727"
+SRCREV = "0bea06d9957e3966d94c48873cd9afefba1c2677"
 SRC_URI += "git://github.com/openvswitch/ovs.git;protocol=https;branch=branch-2.17 \
             file://openvswitch-add-ptest-71d553b995d0bd527d3ab1e9fbaf5a2ae34de2f3.patch \
             file://run-ptest \


### PR DESCRIPTION
This is a regular NILRT distro upstream merge with kirkstone upstream branch.
There were no merge conflicts.
[AB#2657878](https://dev.azure.com/ni/DevCentral/_workitems/edit/2657878)

**Testing**

- [X]  bitbake packagefeed-ni-core
- [X] bitbake packagegroup-ni-desirable
- [X] bitbake package-index && bitbake nilrt-base-system-image
- [X] unpacked resulting nilrt-base-system-image-x64.tar on a VM and verified the target boots into runmode w/o problems.

**Note**

- maintainers please complete this merge manually (i.e. to avoid upstream hashes being changed by GH).