### PR TITLE
Merge latest upstream to kirkstone

### DIFF
--- a/recipes-containers/podman-compose/podman-compose_1.0.3.bb
+++ b/recipes-containers/podman-compose/podman-compose_1.0.3.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 inherit setuptools3
 
-SRC_URI = "git://github.com/containers/podman-compose.git;branch=stable;protocol=https"
+SRC_URI = "git://github.com/containers/podman-compose.git;branch=main;protocol=https"
 
 SRCREV = "24ec539932580a6bc96d6eb2341141b6d7198b39"
 

--- a/recipes-extended/libvirt/libvirt/CVE-2024-1441.patch
+++ b/recipes-extended/libvirt/libvirt/CVE-2024-1441.patch
@@ -1,0 +1,64 @@
+From c664015fe3a7bf59db26686e9ed69af011c6ebb8 Mon Sep 17 00:00:00 2001
+From: Martin Kletzander <mkletzan@redhat.com>
+Date: Tue, 27 Feb 2024 16:20:12 +0100
+Subject: [PATCH] Fix off-by-one error in udevListInterfacesByStatus
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Ever since this function was introduced in 2012 it could've tried
+filling in an extra interface name.  That was made worse in 2019 when
+the caller functions started accepting NULL arrays of size 0.
+
+This is assigned CVE-2024-1441.
+
+Signed-off-by: Martin Kletzander <mkletzan@redhat.com>
+Reported-by: Alexander Kuznetsov <kuznetsovam@altlinux.org>
+Fixes: 5a33366f5c0b18c93d161bd144f9f079de4ac8ca
+Fixes: d6064e2759a24e0802f363e3a810dc5a7d7ebb15
+Reviewed-by: Ján Tomko <jtomko@redhat.com>
+
+Upstream-Status: Backport from [https://launchpad.net/ubuntu/+source/libvirt/8.0.0-1ubuntu7.10]
+CVE: CVE-2024-1441
+Signed-off-by: Ashish Sharma <asharma@mvista.com>
+
+
+ NEWS.rst                               | 15 +++++++++++++++
+ src/interface/interface_backend_udev.c |  2 +-
+ 2 files changed, 16 insertions(+), 1 deletion(-)
+
+#--- a/NEWS.rst
+#+++ b/NEWS.rst
+#@@ -312,6 +312,21 @@ v9.2.0 (2023-04-01)
+# v9.1.0 (2023-03-01)
+# ===================
+# 
+#+  * ``CVE-2024-1441``: Fix off-by-one error leading to a crash
+#+
+#+    In **libvirt-1.0.0** there were couple of interface listing APIs
+#+    introduced which had an off-by-one error.  That error could lead to a
+#+    very rare crash if an array was passed to those functions which did
+#+    not fit all the interfaces.
+#+
+#+    In **libvirt-5.10** a check for non-NULL arrays has been adjusted to
+#+    allow for NULL arrays with size 0 instead of rejecting all NULL
+#+    arrays.  However that made the above issue significantly worse since
+#+    that off-by-one error now did not write beyond an array, but
+#+    dereferenced said NULL pointer making the crash certain in a
+#+    specific scenario in which a NULL array of size 0 was passed to the
+#+    aforementioned functions.
+#+
+# * **Removed features**
+# 
+#   * vbox: removed support for version 5.2 and 6.0 APIs
+--- a/src/interface/interface_backend_udev.c
++++ b/src/interface/interface_backend_udev.c
+@@ -220,7 +220,7 @@ udevListInterfacesByStatus(virConnectPtr
+         g_autoptr(virInterfaceDef) def = NULL;
+ 
+         /* Ensure we won't exceed the size of our array */
+-        if (count > names_len)
++        if (count >= names_len)
+             break;
+ 
+         path = udev_list_entry_get_name(dev_entry);

--- a/recipes-extended/libvirt/libvirt/CVE-2024-2496.patch
+++ b/recipes-extended/libvirt/libvirt/CVE-2024-2496.patch
@@ -1,0 +1,91 @@
+Backport of:
+
+From 2ca94317ac642a70921947150ced8acc674ccdc8 Mon Sep 17 00:00:00 2001
+From: Dmitry Frolov <frolov@swemel.ru>
+Date: Tue, 12 Sep 2023 15:56:47 +0300
+Subject: [PATCH] interface: fix udev_device_get_sysattr_value return value
+ check
+
+Reviewing the code I found that return value of function
+udev_device_get_sysattr_value() is dereferenced without a check.
+udev_device_get_sysattr_value() may return NULL by number of reasons.
+
+v2: VIR_DEBUG added, replaced STREQ(NULLSTR()) with STREQ_NULLABLE()
+v3: More checks added, to skip earlier. More verbose VIR_DEBUG.
+
+Signed-off-by: Dmitry Frolov <frolov@swemel.ru>
+Reviewed-by: Martin Kletzander <mkletzan@redhat.com>
+
+Upstream-Status: Backport from [https://launchpad.net/ubuntu/+source/libvirt/8.0.0-1ubuntu7.10]
+CVE: CVE-2024-2496
+Signed-off-by: Ashish Sharma <asharma@mvista.com>
+
+
+ src/interface/interface_backend_udev.c | 26 +++++++++++++++++++-------
+ 1 file changed, 19 insertions(+), 7 deletions(-)
+
+--- a/src/interface/interface_backend_udev.c
++++ b/src/interface/interface_backend_udev.c
+@@ -23,6 +23,7 @@
+ #include <dirent.h>
+ #include <libudev.h>
+ 
++#include "virlog.h"
+ #include "virerror.h"
+ #include "virfile.h"
+ #include "datatypes.h"
+@@ -41,6 +42,8 @@
+ 
+ #define VIR_FROM_THIS VIR_FROM_INTERFACE
+ 
++VIR_LOG_INIT("interface.interface_backend_udev");
++
+ struct udev_iface_driver {
+     struct udev *udev;
+     /* pid file FD, ensures two copies of the driver can't use the same root */
+@@ -355,11 +358,20 @@ udevConnectListAllInterfaces(virConnectP
+         const char *macaddr;
+         g_autoptr(virInterfaceDef) def = NULL;
+ 
+-        path = udev_list_entry_get_name(dev_entry);
+-        dev = udev_device_new_from_syspath(udev, path);
+-        name = udev_device_get_sysname(dev);
++        if (!(path = udev_list_entry_get_name(dev_entry))) {
++            VIR_DEBUG("Skipping interface, path == NULL");
++            continue;
++        }
++        if (!(dev = udev_device_new_from_syspath(udev, path))) {
++            VIR_DEBUG("Skipping interface '%s', dev == NULL", path);
++            continue;
++        }
++        if (!(name = udev_device_get_sysname(dev))) {
++            VIR_DEBUG("Skipping interface '%s', name == NULL", path);
++            continue;
++        }
+         macaddr = udev_device_get_sysattr_value(dev, "address");
+-        status = STREQ(udev_device_get_sysattr_value(dev, "operstate"), "up");
++        status = STREQ_NULLABLE(udev_device_get_sysattr_value(dev, "operstate"), "up");
+ 
+         def = udevGetMinimalDefForDevice(dev);
+         if (!virConnectListAllInterfacesCheckACL(conn, def)) {
+@@ -969,9 +981,9 @@ udevGetIfaceDef(struct udev *udev, const
+ 
+     /* MTU */
+     mtu_str = udev_device_get_sysattr_value(dev, "mtu");
+-    if (virStrToLong_ui(mtu_str, NULL, 10, &mtu) < 0) {
++    if (!mtu_str || virStrToLong_ui(mtu_str, NULL, 10, &mtu) < 0) {
+         virReportError(VIR_ERR_INTERNAL_ERROR,
+-                _("Could not parse MTU value '%s'"), mtu_str);
++                _("Could not parse MTU value '%1$s'"), NULLSTR(mtu_str));
+         goto error;
+     }
+     ifacedef->mtu = mtu;
+@@ -1094,7 +1106,7 @@ udevInterfaceIsActive(virInterfacePtr if
+        goto cleanup;
+ 
+     /* Check if it's active or not */
+-    status = STREQ(udev_device_get_sysattr_value(dev, "operstate"), "up");
++    status = STREQ_NULLABLE(udev_device_get_sysattr_value(dev, "operstate"), "up");
+ 
+     udev_device_unref(dev);
+ 

--- a/recipes-extended/libvirt/libvirt_8.1.0.bb
+++ b/recipes-extended/libvirt/libvirt_8.1.0.bb
@@ -31,6 +31,8 @@ SRC_URI = "http://libvirt.org/sources/libvirt-${PV}.tar.xz;name=libvirt \
            file://0001-qemu-segmentation-fault-in-virtqemud-executing-qemuD.patch \
            file://CVE-2023-2700.patch \
            file://CVE-2024-2494.patch \
+           file://CVE-2024-1441.patch \
+           file://CVE-2024-2496.patch \
           "
 
 SRC_URI[libvirt.sha256sum] = "3c6c43becffeb34a3f397c616206aa69a893ff8bf5e8208393c84e8e75352934"


### PR DESCRIPTION
[#AB2755009](https://dev.azure.com/ni/DevCentral/_workitems/edit/2755009)

With this PR, the latest changes of meta-openembedded will be merged to nilrt/master/kirkstone. There were no merge conflicts.

**Testing**

- [x]  bitbake packagefeed-ni-core
- [X] bitbake packagegroup-ni-desirable
- [X] bitbake package-index && bitbake nilrt-base-system-image
- [X] unpacked resulting nilrt-base-system-image-x64.tar on a VM and verified the target boots into runmode w/o problems.

Note: @ni/rtos, please complete this merge manually (i.e. to avoid upstream hashes being changed by GH).

Signed-off by: Pratheeksha S N <pratheeksha.s.n@ni.com>