### PR TITLE
docker-moby: enable buildx plugin

### DIFF
--- a/recipes-containers/docker/docker-moby_git.bb
+++ b/recipes-containers/docker/docker-moby_git.bb
@@ -47,15 +47,18 @@ DESCRIPTION = "Linux container runtime \
 SRCREV_moby = "f417435e5f6216828dec57958c490c4f8bae4f98"
 SRCREV_libnetwork = "67e0588f1ddfaf2faf4c8cae8b7ea2876434d91c"
 SRCREV_cli = "01f933261885c0126edb3f47fd56d048ae31265a"
+SRCREV_buildx = "fa4461b9a1ec45c23d1b9e32dee0d0a8ed29900b"
 SRCREV_FORMAT = "moby_libnetwork"
 SRC_URI = "\
 	git://github.com/moby/moby.git;branch=25.0;name=moby;protocol=https \
 	git://github.com/docker/libnetwork.git;branch=master;name=libnetwork;destsuffix=git/libnetwork;protocol=https \
-	git://github.com/docker/cli;branch=25.0;name=cli;destsuffix=git/cli;protocol=https \
+	git://github.com/docker/cli.git;branch=25.0;name=cli;destsuffix=git/cli;protocol=https \
+	git://github.com/docker/buildx.git;branch=v0.18;name=buildx;destsuffix=git/buildx;protocol=https \
 	file://docker.init \
 	file://0001-libnetwork-use-GO-instead-of-go.patch \
-        file://0001-cli-use-external-GO111MODULE-and-cross-compiler.patch \
-        file://0001-dynbinary-use-go-cross-compiler.patch;patchdir=src/import \
+	file://0001-cli-use-external-GO111MODULE-and-cross-compiler.patch \
+	file://0001-dynbinary-use-go-cross-compiler.patch;patchdir=src/import \
+	file://0001-buildx-use-GO-instead-of-go-and-remove-mod-vendor.patch;patchdir=buildx \
 	"
 
 DOCKER_COMMIT = "${SRCREV_moby}"

--- a/recipes-containers/docker/docker.inc
+++ b/recipes-containers/docker/docker.inc
@@ -58,10 +58,11 @@ do_compile() {
 	rm -rf .gopath
 	mkdir -p .gopath/src/"$(dirname "${DOCKER_PKG}")"
 	ln -sf ../../../.. .gopath/src/"${DOCKER_PKG}"
-	
+
 	mkdir -p .gopath/src/github.com/docker
 	ln -sf ${WORKDIR}/git/libnetwork .gopath/src/github.com/docker/libnetwork
 	ln -sf ${WORKDIR}/git/cli .gopath/src/github.com/docker/cli
+	ln -sf ${WORKDIR}/git/buildx .gopath/src/github.com/docker/buildx
 
 	export GOPATH="${S}/src/import/.gopath:${S}/src/import/vendor"
 	export GOROOT="${STAGING_DIR_NATIVE}/${nonarch_libdir}/${HOST_SYS}/go"
@@ -77,14 +78,14 @@ do_compile() {
 
 	export DISABLE_WARN_OUTSIDE_CONTAINER=1
 
-	cd ${S}/src/import/
+	cd ${S}/src/import
 
 	# this is the unsupported built structure
 	# that doesn't rely on an existing docker
 	# to build this:
 	VERSION="${DOCKER_VERSION}" DOCKER_GITCOMMIT="${DOCKER_COMMIT}" ./hack/make.sh dynbinary
 
-        # build the cli
+	# build the cli
 	cd ${S}/src/import/.gopath/src/github.com/docker/cli
 	export CFLAGS=""
 	export LDFLAGS=""
@@ -94,6 +95,10 @@ do_compile() {
 	# build the proxy
 	cd ${S}/src/import/.gopath/src/github.com/docker/libnetwork
 	oe_runmake cross-local
+
+	# build the buildx
+	cd ${S}/src/import/.gopath/src/github.com/docker/buildx
+	VERSION="${DOCKER_VERSION}" DOCKER_GITCOMMIT="${DOCKER_COMMIT}" make build
 }
 
 do_install() {
@@ -122,6 +127,10 @@ do_install() {
 
 	mkdir -p ${D}${datadir}/docker/
 	install -m 0755 ${S}/src/import/contrib/check-config.sh ${D}${datadir}/docker/
+
+	mkdir -p ${D}/${libexecdir}/docker/cli-plugins
+	cp ${WORKDIR}/git/buildx/bin/build/docker-buildx ${D}/${libexecdir}/docker/cli-plugins/docker-buildx
+	install -d ${D}/${libexecdir}/docker/cli-plugins
 }
 
 
@@ -150,12 +159,12 @@ FILES:${PN}-contrib += "${datadir}/docker/check-config.sh"
 RDEPENDS:${PN}-contrib += "bash"
 
 # By the docker-packaging repository and https://docs.docker.com/engine/install/centos/#installation-methods
-# docker is packaged by most distros with a split between the engine and the CLI.
+# docker is packaged by most distros with a split between the engine, the CLI and the buildx plugin.
 #
-# We do the same here, by introducing the -cli package
+# We do the same here, by introducing the -cli and -buildx-plugin package
 #
 # But to keep existing use cases working, we also create a RDEPENDS between the main
-# docker package (the engine) and the cli, so existing "docker" package installs will
+# docker package (the engine) and the cli/buildx plugin, so existing "docker" package installs will
 # continue to work the same way. To have separate and non-redepending packages created
 # set the DOCKER_UNIFIED_PACKAGE variable to False
 #
@@ -166,3 +175,7 @@ FILES:${PN}-cli += "${bindir}/docker"
 # NOT rdepend to get a classic one-package install
 DOCKER_UNIFIED_PACKAGE ?= "True"
 RDEPENDS:${PN} += "${@bb.utils.contains("DOCKER_UNIFIED_PACKAGE", "True", "${PN}-cli", "", d)}"
+
+PACKAGES =+ "${PACKAGE_NAME}-buildx-plugin"
+FILES:${PACKAGE_NAME}-buildx-plugin += "${libexecdir}/docker/cli-plugins/docker-buildx"
+RDEPENDS:${PN} += "${PACKAGE_NAME}-buildx-plugin"

--- a/recipes-containers/docker/files/0001-buildx-use-GO-instead-of-go-and-remove-mod-vendor.patch
+++ b/recipes-containers/docker/files/0001-buildx-use-GO-instead-of-go-and-remove-mod-vendor.patch
@@ -1,0 +1,23 @@
+From 5fc4d96e45904ffc24f151809345f06223e87d48 Mon Sep 17 00:00:00 2001
+From: Can Wong <can.wong@ni.com>
+Date: Thu, 21 Nov 2024 11:47:48 -0600
+Subject: [PATCH] buildx: use GO instead of go and remove mod vendor
+
+Signed-off-by: Can Wong <can.wong@ni.com>
+---
+ hack/build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hack/build b/hack/build
+index 7c23dc10..cd707ec2 100755
+--- a/hack/build
++++ b/hack/build
+@@ -14,4 +14,4 @@ set -e
+ : "${GO_EXTRA_LDFLAGS=}"
+ 
+ set -x
+-CGO_ENABLED=$CGO_ENABLED go build -mod vendor -trimpath ${GO_EXTRA_FLAGS} -ldflags "${GO_LDFLAGS} ${GO_EXTRA_LDFLAGS}" -o "${DESTDIR}/docker-buildx" ./cmd/buildx
++CGO_ENABLED=$CGO_ENABLED ${GO} build -trimpath ${GO_EXTRA_FLAGS} -ldflags "${GO_LDFLAGS} ${GO_EXTRA_LDFLAGS}" -o "${DESTDIR}/docker-buildx" ./cmd/buildx
+-- 
+2.43.0
+


### PR DESCRIPTION
[AB#2939060](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2939060)

Enable docker-buildx-plugin package and have docker-moby depend on it

Testing: 
[x] Built docker-moby locally and verified the creation of docker-buildx binary, docker-buildx-plugin package
[x] Validated docker-moby control lists dependency on docker-buildx-plugin package
[x] Installed docker-buildx-plugin onto a system and verified creating "BuildKit" containers function correctly