### PR TITLE
meta-virtualization: Upstream merge

### DIFF
--- a/recipes-containers/criu/criu_git.bb
+++ b/recipes-containers/criu/criu_git.bb
@@ -21,7 +21,8 @@ SRC_URI = "git://github.com/checkpoint-restore/criu.git;branch=master;protocol=h
            file://0002-criu-Change-libraries-install-directory.patch \
            file://0003-crit-pycriu-build-and-install-wheels.patch \
            file://0004-pycriu-attr-pycriu.version.__version__.patch \
-	   file://0005-pycriu-skip-dependency-check-during-build.patch \
+           file://0005-pycriu-skip-dependency-check-during-build.patch \
+           file://0006-criu-Adjust-to-glibc-__rseq_size-semantic-change.patch \
            "
 
 COMPATIBLE_HOST = "(x86_64|arm|aarch64).*-linux"

--- a/recipes-containers/criu/files/0006-criu-Adjust-to-glibc-__rseq_size-semantic-change.patch
+++ b/recipes-containers/criu/files/0006-criu-Adjust-to-glibc-__rseq_size-semantic-change.patch
@@ -1,0 +1,94 @@
+From 123e558a4bfa8964f9e55d0c0ecc080e6c3a38f3 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Wed, 10 Jul 2024 18:34:50 +0200
+Subject: [PATCH] criu: Adjust to glibc __rseq_size semantic change
+
+In commit 2e456ccf0c34a056e3ccafac4a0c7effef14d918 ("Linux: Make
+__rseq_size useful for feature detection (bug 31965)") glibc 2.40
+changed the meaning of __rseq_size slightly: it is now the size
+of the active/feature area (20 bytes initially), and not the size
+of the entire initially defined struct (32 bytes including padding).
+The reason for the change is that the size including padding does not
+allow detection of newly added features while previously unused
+padding is consumed.
+
+The prep_libc_rseq_info change in criu/cr-restore.c is not necessary
+on kernels which have full ptrace support for obtaining rseq
+information because the code is not used.  On older kernels, it is
+a correctness fix because with size 20 (the new value), rseq
+registeration would fail.
+
+The two other changes are required to make rseq unregistration work
+in tests.
+
+Upstream-Status: Backport [https://github.com/checkpoint-restore/criu/commit/
+089345f77a34d1bc7ef146d650636afcd3cdda21]
+
+Signed-off-by: Florian Weimer <fweimer@redhat.com>
+Signed-off-by: Guocai He <guocai.he.cn@windriver.com>
+---
+ criu/cr-restore.c             | 8 ++++++++
+ test/zdtm/static/rseq00.c     | 5 ++++-
+ test/zdtm/transition/rseq01.c | 5 ++++-
+ 3 files changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/criu/cr-restore.c b/criu/cr-restore.c
+index 270049721..80eb13743 100644
+--- a/criu/cr-restore.c
++++ b/criu/cr-restore.c
+@@ -3103,7 +3103,15 @@ static void prep_libc_rseq_info(struct rst_rseq_param *rseq)
+ 	if (!kdat.has_ptrace_get_rseq_conf) {
+ #if defined(__GLIBC__) && defined(RSEQ_SIG)
+ 		rseq->rseq_abi_pointer = encode_pointer(__criu_thread_pointer() + __rseq_offset);
++		/*
++		 * Current glibc reports the feature/active size in
++		 * __rseq_size, not the size passed to the kernel.
++		 * This could be 20, but older kernels expect 32 for
++		 * the size argument even if only 20 bytes are used.
++		 */
+ 		rseq->rseq_abi_size = __rseq_size;
++		if (rseq->rseq_abi_size < 32)
++			rseq->rseq_abi_size = 32;
+ 		rseq->signature = RSEQ_SIG;
+ #else
+ 		rseq->rseq_abi_pointer = 0;
+diff --git a/test/zdtm/static/rseq00.c b/test/zdtm/static/rseq00.c
+index 471ad6a43..7add7801e 100644
+--- a/test/zdtm/static/rseq00.c
++++ b/test/zdtm/static/rseq00.c
+@@ -46,12 +46,15 @@ static inline void *__criu_thread_pointer(void)
+ static inline void unregister_glibc_rseq(void)
+ {
+ 	struct rseq *rseq = (struct rseq *)((char *)__criu_thread_pointer() + __rseq_offset);
++	unsigned int size = __rseq_size;
+ 
+ 	/* hack: mark glibc rseq structure as failed to register */
+ 	rseq->cpu_id = RSEQ_CPU_ID_REGISTRATION_FAILED;
+ 
+ 	/* unregister rseq */
+-	syscall(__NR_rseq, (void *)rseq, __rseq_size, 1, RSEQ_SIG);
++	if (__rseq_size < 32)
++		size = 32;
++	syscall(__NR_rseq, (void *)rseq, size, 1, RSEQ_SIG);
+ }
+ #else
+ static inline void unregister_glibc_rseq(void)
+diff --git a/test/zdtm/transition/rseq01.c b/test/zdtm/transition/rseq01.c
+index 0fbcc2dca..08a7a8e1a 100644
+--- a/test/zdtm/transition/rseq01.c
++++ b/test/zdtm/transition/rseq01.c
+@@ -33,7 +33,10 @@ static inline void *thread_pointer(void)
+ static inline void unregister_old_rseq(void)
+ {
+ 	/* unregister rseq */
+-	syscall(__NR_rseq, (void *)((char *)thread_pointer() + __rseq_offset), __rseq_size, 1, RSEQ_SIG);
++	unsigned int size = __rseq_size;
++	if (__rseq_size < 32)
++		size = 32;
++	syscall(__NR_rseq, (void *)((char *)thread_pointer() + __rseq_offset), size, 1, RSEQ_SIG);
+ }
+ #else
+ static inline void unregister_old_rseq(void)
+-- 
+2.34.1
+

--- a/recipes-containers/crun/crun/CVE-2025-24965.patch
+++ b/recipes-containers/crun/crun/CVE-2025-24965.patch
@@ -1,0 +1,45 @@
+From 0aec82c2b686f0b1793deed43b46524fe2e8b5a7 Mon Sep 17 00:00:00 2001
+From: Giuseppe Scrivano <gscrivan@redhat.com>
+Date: Tue, 4 Feb 2025 10:19:07 +0100
+Subject: [PATCH] krun: fix CVE-2025-24965
+
+make sure the opened .krun_config.json is below the rootfs directory
+and we don't follow any symlink.
+
+Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
+
+CVE: CVE-2025-24965
+Upstream-Status: Backport [https://github.com/containers/crun/commit/0aec82c2b686f0b1793deed43b46524fe2e8b5a7]
+Signed-off-by: Peter Marko <peter.marko@siemens.com>
+---
+ src/libcrun/handlers/krun.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/libcrun/handlers/krun.c b/src/libcrun/handlers/krun.c
+index 804a17cb..3c7766ba 100644
+--- a/src/libcrun/handlers/krun.c
++++ b/src/libcrun/handlers/krun.c
+@@ -43,6 +43,8 @@
+ /* libkrun has a hard-limit of 8 vCPUs per microVM. */
+ #define LIBKRUN_MAX_VCPUS 8
+ 
++#define KRUN_CONFIG_FILE ".krun_config.json"
++
+ struct krun_config
+ {
+   void *handle;
+@@ -207,7 +209,13 @@ libkrun_configure_container (void *cookie, enum handler_configure_phase phase,
+       if (UNLIKELY (ret < 0))
+         return ret;
+ 
+-      ret = write_file_at (rootfsfd, ".krun_config.json", config, config_size, err);
++      /* CVE-2025-24965: the content below rootfs cannot be trusted because it is controlled by the user.  We
++         must ensure the file is opened below the rootfs directory.  */
++      fd = safe_openat (rootfsfd, rootfs, KRUN_CONFIG_FILE, WRITE_FILE_DEFAULT_FLAGS | O_NOFOLLOW, 0700, err);
++      if (UNLIKELY (fd < 0))
++        return fd;
++
++      ret = safe_write (fd, KRUN_CONFIG_FILE, config, config_size, err);
+       if (UNLIKELY (ret < 0))
+         return ret;
+     }

--- a/recipes-containers/crun/crun_git.bb
+++ b/recipes-containers/crun/crun_git.bb
@@ -15,6 +15,7 @@ SRC_URI = "git://github.com/containers/crun.git;branch=main;name=crun;protocol=h
            git://github.com/opencontainers/runtime-spec.git;branch=main;name=rspec;destsuffix=git/libocispec/runtime-spec;protocol=https \
            git://github.com/opencontainers/image-spec.git;branch=main;name=ispec;destsuffix=git/libocispec/image-spec;protocol=https \
            git://github.com/containers/yajl.git;branch=main;name=yajl;destsuffix=git/libocispec/yajl;protocol=https \
+           file://CVE-2025-24965.patch \
           "
 
 PV = "v1.14.3+git${SRCREV_crun}"

--- a/recipes-containers/docker-distribution/docker-distribution_git.bb
+++ b/recipes-containers/docker-distribution/docker-distribution_git.bb
@@ -8,6 +8,7 @@ SRC_URI = "git://github.com/docker/distribution.git;branch=release/2.8;name=dist
            file://docker-registry.service \
            file://0001-build-use-to-use-cross-go-compiler.patch \
            file://0001-panicwrap-Use-dup3-on-riscv64-linux.patch \
+           file://0001-Fix-registry-token-authentication-bug.patch \
           "
 
 PACKAGES =+ "docker-registry"

--- a/recipes-containers/docker-distribution/files/0001-Fix-registry-token-authentication-bug.patch
+++ b/recipes-containers/docker-distribution/files/0001-Fix-registry-token-authentication-bug.patch
@@ -1,0 +1,49 @@
+From ff9eed251cfd7dd279ea231a289cc784fd7f829f Mon Sep 17 00:00:00 2001
+From: Milos Gajdos <milosthegajdos@gmail.com>
+Date: Sat, 1 Feb 2025 15:30:18 -0800
+Subject: [PATCH] Fix registry token authentication bug
+
+When a JWT contains a JWK header without a certificate chain,
+the original code only checked if the KeyID (kid) matches one of the trusted keys,
+but doesn't verify that the actual key material matches.
+
+As a result, if an attacker guesses the kid, they can inject an
+untrusted key which would then be used to grant access to protected
+data.
+
+This fixes the issue such as only the trusted key is verified.
+
+Signed-off-by: Milos Gajdos <milosthegajdos@gmail.com>
+
+CVE: CVE-2025-24976
+
+Upstream-Status: Backport [https://github.com/distribution/distribution/commit/f4a500caf68169dccb0b54cb90523e68ee1ac2be]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ registry/auth/token/token.go | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/registry/auth/token/token.go b/registry/auth/token/token.go
+index f803415f..fbcf5bfa 100644
+--- a/registry/auth/token/token.go
++++ b/registry/auth/token/token.go
+@@ -290,12 +290,13 @@ func parseAndVerifyRawJWK(rawJWK *json.RawMessage, verifyOpts VerifyOptions) (pu
+ 	x5cVal, ok := pubKey.GetExtendedField("x5c").([]interface{})
+ 	if !ok {
+ 		// The JWK should be one of the trusted root keys.
+-		if _, trusted := verifyOpts.TrustedKeys[pubKey.KeyID()]; !trusted {
++		trustedKey, trusted := verifyOpts.TrustedKeys[pubKey.KeyID()]
++		if !trusted {
+ 			return nil, errors.New("untrusted JWK with no certificate chain")
+ 		}
+ 
+ 		// The JWK is one of the trusted keys.
+-		return
++		return trustedKey, nil
+ 	}
+ 
+ 	// Ensure each item in the chain is of the correct type.
+-- 
+2.25.1
+

--- a/recipes-containers/docker/docker-moby_git.bb
+++ b/recipes-containers/docker/docker-moby_git.bb
@@ -56,6 +56,7 @@ SRC_URI = "\
 	file://0001-libnetwork-use-GO-instead-of-go.patch \
         file://0001-cli-use-external-GO111MODULE-and-cross-compiler.patch \
         file://0001-dynbinary-use-go-cross-compiler.patch;patchdir=src/import \
+        file://CVE-2024-36620.patch;patchdir=src/import \
 	"
 
 DOCKER_COMMIT = "${SRCREV_moby}"

--- a/recipes-containers/docker/docker-moby_git.bb
+++ b/recipes-containers/docker/docker-moby_git.bb
@@ -57,6 +57,7 @@ SRC_URI = "\
         file://0001-cli-use-external-GO111MODULE-and-cross-compiler.patch \
         file://0001-dynbinary-use-go-cross-compiler.patch;patchdir=src/import \
         file://CVE-2024-36620.patch;patchdir=src/import \
+        file://CVE-2024-36621.patch;patchdir=src/import \
 	"
 
 DOCKER_COMMIT = "${SRCREV_moby}"

--- a/recipes-containers/docker/files/CVE-2024-36620.patch
+++ b/recipes-containers/docker/files/CVE-2024-36620.patch
@@ -1,0 +1,40 @@
+From ab570ab3d62038b3d26f96a9bb585d0b6095b9b4 Mon Sep 17 00:00:00 2001
+From: Christopher Petito <47751006+krissetto@users.noreply.github.com>
+Date: Fri, 19 Apr 2024 10:44:30 +0000
+Subject: [PATCH] nil dereference fix on image history Created value
+
+Issue was caused by the changes here https://github.com/moby/moby/pull/45504
+First released in v25.0.0-beta.1
+
+CVE: CVE-2024-36620
+
+Upstream-Status:
+Backport [https://github.com/moby/moby/commit/ab570ab3d62038b3d26f96a9bb585d0b6095b9b4]
+
+Signed-off-by: Praveen Kumar <praveen.kumar@windriver.com>
+---
+ daemon/images/image_history.go | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/daemon/images/image_history.go b/daemon/images/image_history.go
+index dcf7a906aa..e5adda8639 100644
+--- a/daemon/images/image_history.go
++++ b/daemon/images/image_history.go
+@@ -41,10 +41,14 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*image.
+			layer.ReleaseAndLog(i.layerStore, l)
+			layerCounter++
+		}
++		var created int64
++		if h.Created != nil {
++			created = h.Created.Unix()
++		}
+
+		history = append([]*image.HistoryResponseItem{{
+			ID:        "<missing>",
+-			Created:   h.Created.Unix(),
++			Created:   created,
+			CreatedBy: h.CreatedBy,
+			Comment:   h.Comment,
+			Size:      layerSize,
+--
+2.40.0

--- a/recipes-containers/docker/files/CVE-2024-36620.patch
+++ b/recipes-containers/docker/files/CVE-2024-36620.patch
@@ -8,8 +8,7 @@ First released in v25.0.0-beta.1
 
 CVE: CVE-2024-36620
 
-Upstream-Status:
-Backport [https://github.com/moby/moby/commit/ab570ab3d62038b3d26f96a9bb585d0b6095b9b4]
+Upstream-Status: Backport [https://github.com/moby/moby/commit/ab570ab3d62038b3d26f96a9bb585d0b6095b9b4]
 
 Signed-off-by: Praveen Kumar <praveen.kumar@windriver.com>
 ---

--- a/recipes-containers/docker/files/CVE-2024-36621.patch
+++ b/recipes-containers/docker/files/CVE-2024-36621.patch
@@ -1,0 +1,83 @@
+From 37545cc644344dcb576cba67eb7b6f51a463d31e Mon Sep 17 00:00:00 2001
+From: Tonis Tiigi <tonistiigi@gmail.com>
+Date: Wed, 6 Mar 2024 23:11:32 -0800
+Subject: [PATCH] builder-next: fix missing lock in ensurelayer
+
+When this was called concurrently from the moby image
+exporter there could be a data race where a layer was
+written to the refs map when it was already there.
+
+In that case the reference count got mixed up and on
+release only one of these layers was actually released.
+
+CVE: CVE-2024-36621
+
+Upstream-Status:
+Backport [https://github.com/moby/moby/commit/37545cc644344dcb576cba67eb7b6f51a463d31e]
+
+Signed-off-by: Praveen Kumar <praveen.kumar@windriver.com>
+---
+ .../builder-next/adapters/snapshot/layer.go   |  3 +++
+ .../adapters/snapshot/snapshot.go             | 19 +++++++++++--------
+ 2 files changed, 14 insertions(+), 8 deletions(-)
+
+diff --git a/builder/builder-next/adapters/snapshot/layer.go b/builder/builder-next/adapters/snapshot/layer.go
+index 73120ea70b..fc83058339 100644
+--- a/builder/builder-next/adapters/snapshot/layer.go
++++ b/builder/builder-next/adapters/snapshot/layer.go
+@@ -22,6 +22,9 @@ func (s *snapshotter) GetDiffIDs(ctx context.Context, key string) ([]layer.DiffI
+ }
+
+ func (s *snapshotter) EnsureLayer(ctx context.Context, key string) ([]layer.DiffID, error) {
++	s.layerCreateLocker.Lock(key)
++	defer s.layerCreateLocker.Unlock(key)
++
+	diffIDs, err := s.GetDiffIDs(ctx, key)
+	if err != nil {
+		return nil, err
+diff --git a/builder/builder-next/adapters/snapshot/snapshot.go b/builder/builder-next/adapters/snapshot/snapshot.go
+index a0d28ad984..510ffefb49 100644
+--- a/builder/builder-next/adapters/snapshot/snapshot.go
++++ b/builder/builder-next/adapters/snapshot/snapshot.go
+@@ -17,6 +17,7 @@ import (
+	"github.com/moby/buildkit/identity"
+	"github.com/moby/buildkit/snapshot"
+	"github.com/moby/buildkit/util/leaseutil"
++	"github.com/moby/locker"
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+	bolt "go.etcd.io/bbolt"
+@@ -51,10 +52,11 @@ type checksumCalculator interface {
+ type snapshotter struct {
+	opt Opt
+
+-	refs map[string]layer.Layer
+-	db   *bolt.DB
+-	mu   sync.Mutex
+-	reg  graphIDRegistrar
++	refs              map[string]layer.Layer
++	db                *bolt.DB
++	mu                sync.Mutex
++	reg               graphIDRegistrar
++	layerCreateLocker *locker.Locker
+ }
+
+ // NewSnapshotter creates a new snapshotter
+@@ -71,10 +73,11 @@ func NewSnapshotter(opt Opt, prevLM leases.Manager, ns string) (snapshot.Snapsho
+	}
+
+	s := &snapshotter{
+-		opt:  opt,
+-		db:   db,
+-		refs: map[string]layer.Layer{},
+-		reg:  reg,
++		opt:               opt,
++		db:                db,
++		refs:              map[string]layer.Layer{},
++		reg:               reg,
++		layerCreateLocker: locker.New(),
+	}
+
+	slm := newLeaseManager(s, prevLM)
+--
+2.40.0

--- a/recipes-containers/docker/files/CVE-2024-36621.patch
+++ b/recipes-containers/docker/files/CVE-2024-36621.patch
@@ -12,8 +12,7 @@ release only one of these layers was actually released.
 
 CVE: CVE-2024-36621
 
-Upstream-Status:
-Backport [https://github.com/moby/moby/commit/37545cc644344dcb576cba67eb7b6f51a463d31e]
+Upstream-Status: Backport [https://github.com/moby/moby/commit/37545cc644344dcb576cba67eb7b6f51a463d31e]
 
 Signed-off-by: Praveen Kumar <praveen.kumar@windriver.com>
 ---

--- a/recipes-containers/tini/tini/0001-Support-POSIX-basename-from-musl-libc.patch
+++ b/recipes-containers/tini/tini/0001-Support-POSIX-basename-from-musl-libc.patch
@@ -1,0 +1,76 @@
+From 10479a6eef32f8e64fd5bf894dee9c7a6f21ce4c Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Sun, 14 Apr 2024 15:33:51 +0200
+Subject: [PATCH] Support POSIX basename() from musl libc
+
+Musl libc 1.2.5 removed the definition of the basename() function from
+string.h and only provides it in libgen.h as the POSIX standard
+defines it.
+
+This change fixes compilation with musl libc 1.2.5.
+````
+build_dir/target-mips_24kc_musl/tini-0.19.0/src/tini.c:227:36: error: implicit declaration of function 'basename' [-Wimplicit-function-declaration]
+  227 |         fprintf(file, "%s (%s)\n", basename(name), TINI_VERSION_STRING);
+build_dir/target-mips_24kc_musl/tini-0.19.0/src/tini.c:227:25: error: format '%s' expects argument of type 'char *', but argument 3 has type 'int' [-Werror=format=]
+  227 |         fprintf(file, "%s (%s)\n", basename(name), TINI_VERSION_STRING);
+      |                        ~^          ~~~~~~~~~~~~~~
+      |                         |          |
+      |                         char *     int
+      |                        %d
+
+````
+
+basename() modifies the input string, copy it first with strdup(), If
+strdup() returns NULL the code will handle it.
+
+Upstream-Status: Submitted [https://github.com/krallin/tini/pull/223]
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ src/tini.c | 15 +++++++++++----
+ 1 file changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/src/tini.c b/src/tini.c
+index 7914d3a..41d1506 100644
+--- a/src/tini.c
++++ b/src/tini.c
+@@ -14,6 +14,7 @@
+ #include <stdlib.h>
+ #include <unistd.h>
+ #include <stdbool.h>
++#include <libgen.h>
+ 
+ #include "tiniConfig.h"
+ #include "tiniLicense.h"
+@@ -224,14 +225,19 @@ int spawn(const signal_configuration_t* const sigconf_ptr, char* const argv[], i
+ }
+ 
+ void print_usage(char* const name, FILE* const file) {
+-	fprintf(file, "%s (%s)\n", basename(name), TINI_VERSION_STRING);
++	char *dirc, *bname;
++
++	dirc = strdup(name);
++	bname = basename(dirc);
++
++	fprintf(file, "%s (%s)\n", bname, TINI_VERSION_STRING);
+ 
+ #if TINI_MINIMAL
+-	fprintf(file, "Usage: %s PROGRAM [ARGS] | --version\n\n", basename(name));
++	fprintf(file, "Usage: %s PROGRAM [ARGS] | --version\n\n", bname);
+ #else
+-	fprintf(file, "Usage: %s [OPTIONS] PROGRAM -- [ARGS] | --version\n\n", basename(name));
++	fprintf(file, "Usage: %s [OPTIONS] PROGRAM -- [ARGS] | --version\n\n", bname);
+ #endif
+-	fprintf(file, "Execute a program under the supervision of a valid init process (%s)\n\n", basename(name));
++	fprintf(file, "Execute a program under the supervision of a valid init process (%s)\n\n", bname);
+ 
+ 	fprintf(file, "Command line options:\n\n");
+ 
+@@ -261,6 +267,7 @@ void print_usage(char* const name, FILE* const file) {
+ 	fprintf(file, "  %s: Send signals to the child's process group.\n", KILL_PROCESS_GROUP_GROUP_ENV_VAR);
+ 
+ 	fprintf(file, "\n");
++	free(dirc);
+ }
+ 
+ void print_license(FILE* const file) {

--- a/recipes-containers/tini/tini_0.19.0.bb
+++ b/recipes-containers/tini/tini_0.19.0.bb
@@ -9,6 +9,7 @@ SRC_URI = " \
   git://github.com/krallin/tini.git;branch=master;protocol=https \
   file://0001-Do-not-strip-the-output-binary-allow-yocto-to-do-thi.patch \
   file://0001-tini.c-a-function-declaration-without-a-prototype-is.patch \
+  file://0001-Support-POSIX-basename-from-musl-libc.patch \
   "
 
 LICENSE = "MIT"

--- a/recipes-networking/openvswitch/openvswitch-git/openvswitch-add-ptest-71d553b995d0bd527d3ab1e9fbaf5a2ae34de2f3.patch
+++ b/recipes-networking/openvswitch/openvswitch-git/openvswitch-add-ptest-71d553b995d0bd527d3ab1e9fbaf5a2ae34de2f3.patch
@@ -16,6 +16,13 @@ Signed-off-by: He Zhe <zhe.he@windriver.com>
 refresh patch to fix patch-fuzz warning
 Signed-off-by: Changqing Li <changqing.li@windriver.com>
 
+Refresh patch to fix file ptest/tests/atlocal 
+contains reference to TMPDIR [buildpaths]. The fix is:
+ - set EGREP to "grep -E" in ptest/tests/atlocal
+ - set CFLAGS to " " in ptest/tests/atlocal
+
+Signed-off-by: Bin Lan <bin.lan.cn@windriver.com>
+
 Upstream-Status: Inappropriate [embedded specific]
 ---
  Makefile.am |  1 +
@@ -37,7 +44,7 @@ new file mode 100644
 index 0000000..0b4587c
 --- /dev/null
 +++ b/test.mk
-@@ -0,0 +1,74 @@
+@@ -0,0 +1,76 @@
 +TEST_DEST ?= ${prefix}/lib/openvswitch
 +TEST_ROOT ?= ${prefix}/lib/openvswitch
 +TEST_DEPEND =
@@ -112,3 +119,5 @@ index 0000000..0b4587c
 +	sed -i 's|$$srcdir|$$abs_srcdir|g' $(TEST_DEST)/tests/testsuite
 +	sed -i 's|ovs-appctl-bashcomp\.bash|/etc/bash_completion.d/ovs-appctl-bashcomp\.bash|g' $(TEST_DEST)/tests/testsuite
 +	sed -i 's|ovs-vsctl-bashcomp\.bash|/etc/bash_completion.d/ovs-vsctl-bashcomp\.bash|g' $(TEST_DEST)/tests/testsuite
++	sed -i 's|EGREP=.*|EGREP='"'"'grep -E'"'"'|g' $(TEST_DEST)/tests/atlocal
++	sed -i 's|CFLAGS=.*|CFLAGS='"'"' '"'"'|g' $(TEST_DEST)/tests/atlocal


### PR DESCRIPTION
This is the periodic currency merge with upstream `scarthgap` branch.

Did the merge using `upstream_merge.sh` script.

Resolved trivial conflict with cf5a54d ("docker-moby: enable buildx plugin")

WI: [AB#3039641](https://dev.azure.com/ni/DevCentral/_workitems/edit/3039641)

### Testing
- [x] `bitbake packagefeed-ni-core`
- [x] `bitbake packagegroup-ni-desirable`
- [x] `bitbake package-index` && `bitbake nilrt-base-system-image`
- [x] Installed BSI on a VM and verified it boots

### Note to maintainers
Please complete this merge manually to avoid upstream hashes being changed by GH.