### PR TITLE
docker: sync recipe with upstream and drop stale libnetwork references

### DIFF
--- a/recipes-containers/docker/docker-moby_git.bb
+++ b/recipes-containers/docker/docker-moby_git.bb
@@ -51,7 +51,7 @@ SRCREV_FORMAT = "moby"
 SRC_URI = "\
 	git://github.com/moby/moby.git;nobranch=1;name=moby;protocol=https;destsuffix=${GO_SRCURI_DESTSUFFIX} \
 	git://github.com/docker/cli.git;nobranch=1;name=cli;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/cli;protocol=https \
-	git://github.com/docker/buildx.git;branch=v0.18;name=buildx;destsuffix=git/buildx;protocol=https \
+	git://github.com/docker/buildx.git;branch=v0.18;name=buildx;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/buildx;protocol=https \
 	file://docker.init \
 	file://0001-cli-use-external-GO111MODULE-and-cross-compiler.patch \
 	file://0001-dynbinary-use-go-cross-compiler.patch;patchdir=src/import \

--- a/recipes-containers/docker/docker.inc
+++ b/recipes-containers/docker/docker.inc
@@ -102,10 +102,6 @@ do_compile() {
 	export DOCKER_VERSION=${DOCKER_VERSION}
 	VERSION="${DOCKER_VERSION}" DOCKER_GITCOMMIT="${DOCKER_COMMIT}" make dynbinary
 
-	# build the proxy
-	cd ${S}/src/import/.gopath/src/github.com/docker/libnetwork
-	oe_runmake cross-local
-
 	# build the buildx
 	cd ${S}/src/import/.gopath/src/github.com/docker/buildx
 	VERSION="${DOCKER_VERSION}" DOCKER_GITCOMMIT="${DOCKER_COMMIT}" make build

--- a/recipes-containers/docker/docker.inc
+++ b/recipes-containers/docker/docker.inc
@@ -135,7 +135,7 @@ do_install() {
 	install -m 0755 ${S}/src/import/contrib/check-config.sh ${D}${datadir}/docker/
 
 	mkdir -p ${D}/${libexecdir}/docker/cli-plugins
-	cp ${WORKDIR}/git/buildx/bin/build/docker-buildx ${D}/${libexecdir}/docker/cli-plugins/docker-buildx
+	cp ${S}/buildx/bin/build/docker-buildx ${D}/${libexecdir}/docker/cli-plugins/docker-buildx
 	install -d ${D}/${libexecdir}/docker/cli-plugins
 }
 

--- a/recipes-containers/docker/files/0001-buildx-use-GO-instead-of-go-and-remove-mod-vendor.patch
+++ b/recipes-containers/docker/files/0001-buildx-use-GO-instead-of-go-and-remove-mod-vendor.patch
@@ -3,7 +3,11 @@ From: Can Wong <can.wong@ni.com>
 Date: Thu, 21 Nov 2024 11:47:48 -0600
 Subject: [PATCH] buildx: use GO instead of go and remove mod vendor
 
+Upstream-Status: Pending
+
 Signed-off-by: Can Wong <can.wong@ni.com>
+[shubhanshumt26: Added Upstream-Status tag]
+Signed-off-by: Shubhanshu Mani Tripathi <shubhanshu.mani.tripathi@emerson.com>
 ---
  hack/build | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)


### PR DESCRIPTION
This PR updates the Docker recipe in meta-virtualization to:

- Align it with the current upstream repository structure.
- Remove stale libnetwork merge artifacts that were unintentionally carried forward.
- Add a missing `Upstream-Status` tag to a patch to avoid QA warnings.

These changes ensure the recipe stays consistent with upstream Docker sources and resolves the associated layer maintenance issues.

### Justification
[AB#3039672](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3039672)

### Testing

- [x] `docker-moby` recipe builts successfully with this PR in place.