### PR TITLE
runc-opencontainers: Update to v1.2.8

### DIFF
--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -1,11 +1,11 @@
 include runc.inc
 
-SRCREV = "4774df387790afbddcd2fd905d70ecb8aec9c341"
+SRCREV = "eeb7e6024f9ee43876301b1d23c353384fa6dcdd"
 SRC_URI = " \
     git://github.com/opencontainers/runc;branch=release-1.2;protocol=https \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
     "
-RUNC_VERSION = "1.2.7"
+RUNC_VERSION = "1.2.8"
 
 CVE_PRODUCT = "runc"
 


### PR DESCRIPTION
Update `runc-opencontainers` to v1.2.8 to address CVE-2025-31133, CVE-2025-52565 and CVE-2025-52881
[AB#3595777](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3595777)

### Testing
* [x] bitbake packagefeed-ni-core (x64 and ARM)
* [x] bitbake packagegroup-ni-desirable (x64 and ARM)
* [x] bitbake nilrt-safemode-rootfs (x64 only)
* [x] bitbake nilrt-base-system-image (x64 and ARM)
* [x] Installed runc-opencontainers on target system (x64)

### Note to Reviewers
Differences found between 1.1.14 and 1.2.8
- runc 1.2.8 no longer contains `--criu` option