### PR TITLE
meta-virtualization: Currency merge with upstream scarthgap branch

### DIFF
--- a/recipes-containers/containerd/containerd-opencontainers_git.bb
+++ b/recipes-containers/containerd/containerd-opencontainers_git.bb
@@ -5,7 +5,7 @@ DESCRIPTION = "containerd is a daemon to control runC, built for performance and
                support as well as checkpoint and restore for cloning and live migration of containers."
 
 
-SRCREV = "4ac6c20c7bbf8177f29e46bbdc658fec02ffb8ad"
+SRCREV = "ffa3ba0cfc08e443758c01c73a69db403d31ad1b"
 SRC_URI = "git://github.com/containerd/containerd;branch=release/2.0;protocol=https;destsuffix=git/src/github.com/containerd/containerd/v2 \
            file://0001-Makefile-allow-GO_BUILD_FLAGS-to-be-externally-speci.patch \
            file://0001-build-don-t-use-gcflags-to-define-trimpath.patch \
@@ -15,8 +15,8 @@ SRC_URI = "git://github.com/containerd/containerd;branch=release/2.0;protocol=ht
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1269f40c0d099c21a871163984590d89"
 
-CONTAINERD_VERSION = "v2.0.7"
-CVE_VERSION = "2.0.7"
+CONTAINERD_VERSION = "v2.0.10"
+CVE_VERSION = "2.0.10"
 
 # EXTRA_OEMAKE += "GODEBUG=1"
 

--- a/recipes-containers/docker/docker-moby_git.bb
+++ b/recipes-containers/docker/docker-moby_git.bb
@@ -60,6 +60,8 @@ SRC_URI = "\
 		file://CVE-2026-34040_p1.patch;patchdir=src/import \
 		file://CVE-2026-34040_p2.patch;patchdir=src/import \
 		file://CVE-2026-41568.patch;patchdir=src/import \
+		file://CVE-2026-42306_p1.patch;patchdir=src/import \
+		file://CVE-2026-42306_p2.patch;patchdir=src/import \
 	"
 
 DOCKER_COMMIT = "${SRCREV_moby}"

--- a/recipes-containers/docker/docker-moby_git.bb
+++ b/recipes-containers/docker/docker-moby_git.bb
@@ -59,6 +59,7 @@ SRC_URI = "\
 		file://CVE-2026-33997.patch;patchdir=src/import \
 		file://CVE-2026-34040_p1.patch;patchdir=src/import \
 		file://CVE-2026-34040_p2.patch;patchdir=src/import \
+		file://CVE-2026-41568.patch;patchdir=src/import \
 	"
 
 DOCKER_COMMIT = "${SRCREV_moby}"

--- a/recipes-containers/docker/files/CVE-2026-41568.patch
+++ b/recipes-containers/docker/files/CVE-2026-41568.patch
@@ -1,0 +1,275 @@
+From 9afb2d06f1d14b71be59d6662d4da2deacfb45fc Mon Sep 17 00:00:00 2001
+From: Deepak Rathore <deeratho@cisco.com>
+Date: Tue, 30 Jun 2026 05:16:06 -0700
+Subject: [PATCH] daemon/copy: Fix symlink escape in mount destination creation
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Use os.Root to scope all filesystem operations in createIfNotExists to
+the container root directory.
+
+This prevents a TOCTOU attack where a container process swaps a path
+component with a symlink between GetResourcePath resolution and
+directory/file creation, which could allow writing to arbitrary host
+paths outside the container.
+
+CVE: CVE-2026-41568
+Upstream-Status: Backport [https://github.com/moby/moby/commit/742e28ed8d654372f0aa5b549da74c2f6e674194]
+
+Backport Changes:
+- Replaced upstream os.Root operations with dirfd-relative
+  openat(2)/mkdirat(2) helpers, because Scarthgap uses Go 1.22 and
+  does not provide os.Root.
+- Kept O_NOFOLLOW while walking each path component so the backport
+  preserves the upstream root-scoped symlink protection.
+- Adapted the createIfNotExists unit test to open the container root
+  with unix.Open.
+
+(cherry picked from commit 64a22d80b93ddc1416b501b5145df02947312249)
+Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>
+(cherry picked from commit 742e28ed8d654372f0aa5b549da74c2f6e674194)
+Signed-off-by: Deepak Rathore <deeratho@cisco.com>
+---
+ daemon/containerfs_linux.go      | 148 +++++++++++++++++++-
+ daemon/containerfs_linux_test.go |  51 +++++++
+ 2 files changed, 197 insertions(+), 2 deletions(-)
+ create mode 100644 daemon/containerfs_linux_test.go
+
+diff --git a/daemon/containerfs_linux.go b/daemon/containerfs_linux.go
+index 384c86b..ab6b199 100644
+--- a/daemon/containerfs_linux.go
++++ b/daemon/containerfs_linux.go
+@@ -19,7 +19,6 @@ import (
+ 	"github.com/docker/docker/container"
+ 	"github.com/docker/docker/internal/mounttree"
+ 	"github.com/docker/docker/internal/unshare"
+-	"github.com/docker/docker/pkg/fileutils"
+ )
+ 
+ type future struct {
+@@ -83,6 +82,13 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
+ 			if err := mount.MakeRSlave("/"); err != nil {
+ 				return err
+ 			}
++
++			rootFd, err := unix.Open(container.BaseFS, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
++			if err != nil {
++				return fmt.Errorf("open container root: %w", err)
++			}
++			defer unix.Close(rootFd)
++
+ 			for _, m := range mounts {
+ 				dest, err := container.GetResourcePath(m.Destination)
+ 				if err != nil {
+@@ -94,7 +100,7 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
+ 				if err != nil {
+ 					return err
+ 				}
+-				if err := fileutils.CreateIfNotExists(dest, stat.IsDir()); err != nil {
++				if err := createIfNotExists(rootFd, strings.TrimPrefix(m.Destination, "/"), stat.IsDir()); err != nil {
+ 					return err
+ 				}
+ 
+@@ -242,6 +248,144 @@ func (vw *containerFSView) Stat(ctx context.Context, path string) (*types.Contai
+ 	return stat, err
+ }
+ 
++// createIfNotExists creates a file or directory below rootFd only if it does
++// not already exist. Path components are opened dirfd-relative with
++// O_NOFOLLOW so a container cannot swap in a symlink that escapes BaseFS.
++func createIfNotExists(rootFd int, unsafePath string, isDir bool) error {
++	if isDir {
++		return mkdirAllInRoot(rootFd, unsafePath)
++	}
++
++	parentPath := filepath.Dir(unsafePath)
++	if parentPath != "." && parentPath != "/" {
++		if err := mkdirAllInRoot(rootFd, parentPath); err != nil {
++			return err
++		}
++	}
++
++	parentFd, base, closeParent, err := openParentInRoot(rootFd, unsafePath)
++	if err != nil {
++		return err
++	}
++	if closeParent {
++		defer unix.Close(parentFd)
++	}
++
++	fd, err := unix.Openat(parentFd, base, unix.O_CREAT|unix.O_WRONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o755)
++	if err != nil {
++		return err
++	}
++	return unix.Close(fd)
++}
++
++func mkdirAllInRoot(rootFd int, unsafePath string) error {
++	parts, err := pathComponents(unsafePath)
++	if err != nil {
++		return err
++	}
++
++	currentFd := rootFd
++	closeCurrent := false
++	for _, part := range parts {
++		nextFd, err := openDirAtNoFollow(currentFd, part)
++		if os.IsNotExist(err) {
++			if err := unix.Mkdirat(currentFd, part, 0o755); err != nil && !os.IsExist(err) {
++				if closeCurrent {
++					unix.Close(currentFd)
++				}
++				return err
++			}
++			nextFd, err = openDirAtNoFollow(currentFd, part)
++		}
++		if err != nil {
++			if closeCurrent {
++				unix.Close(currentFd)
++			}
++			return err
++		}
++		if closeCurrent {
++			unix.Close(currentFd)
++		}
++		currentFd = nextFd
++		closeCurrent = true
++	}
++	if closeCurrent {
++		return unix.Close(currentFd)
++	}
++	return nil
++}
++
++func openParentInRoot(rootFd int, unsafePath string) (parentFd int, base string, closeParent bool, err error) {
++	parts, err := pathComponents(unsafePath)
++	if err != nil {
++		return -1, "", false, err
++	}
++	if len(parts) == 0 {
++		return -1, "", false, fmt.Errorf("empty path")
++	}
++	base = parts[len(parts)-1]
++	if len(parts) == 1 {
++		return rootFd, base, false, nil
++	}
++
++	parentFd, err = openDirInRoot(rootFd, filepath.Join(parts[:len(parts)-1]...))
++	if err != nil {
++		return -1, "", false, err
++	}
++	return parentFd, base, true, nil
++}
++
++func openDirInRoot(rootFd int, unsafePath string) (int, error) {
++	parts, err := pathComponents(unsafePath)
++	if err != nil {
++		return -1, err
++	}
++	if len(parts) == 0 {
++		return rootFd, nil
++	}
++
++	currentFd := rootFd
++	closeCurrent := false
++	for _, part := range parts {
++		nextFd, err := openDirAtNoFollow(currentFd, part)
++		if err != nil {
++			if closeCurrent {
++				unix.Close(currentFd)
++			}
++			return -1, err
++		}
++		if closeCurrent {
++			unix.Close(currentFd)
++		}
++		currentFd = nextFd
++		closeCurrent = true
++	}
++	return currentFd, nil
++}
++
++func openDirAtNoFollow(rootFd int, name string) (int, error) {
++	return unix.Openat(rootFd, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
++}
++
++func pathComponents(unsafePath string) ([]string, error) {
++	if filepath.IsAbs(unsafePath) {
++		return nil, fmt.Errorf("absolute path %q is not scoped to container root", unsafePath)
++	}
++
++	cleanPath := filepath.Clean(unsafePath)
++	if cleanPath == "." {
++		return nil, nil
++	}
++
++	parts := strings.Split(cleanPath, string(os.PathSeparator))
++	for _, part := range parts {
++		if part == "" || part == "." || part == ".." {
++			return nil, fmt.Errorf("path %q escapes container root", unsafePath)
++		}
++	}
++	return parts, nil
++}
++
+ // makeMountRRO makes the mount recursively read-only.
+ func makeMountRRO(dest string) error {
+ 	attr := &unix.MountAttr{
+diff --git a/daemon/containerfs_linux_test.go b/daemon/containerfs_linux_test.go
+new file mode 100644
+index 0000000..08d797b
+--- /dev/null
++++ b/daemon/containerfs_linux_test.go
+@@ -0,0 +1,51 @@
++package daemon // import "github.com/docker/docker/daemon"
++
++import (
++	"os"
++	"path/filepath"
++	"testing"
++
++	"golang.org/x/sys/unix"
++	"gotest.tools/v3/assert"
++)
++
++func TestCreateIfNotExists(t *testing.T) {
++	t.Run("directory", func(t *testing.T) {
++		dir := t.TempDir()
++		rootFd := openRootFd(t, dir)
++		defer unix.Close(rootFd)
++
++		err := createIfNotExists(rootFd, "tocreate", true)
++		assert.NilError(t, err)
++
++		fileinfo, err := os.Stat(filepath.Join(dir, "tocreate"))
++		assert.NilError(t, err, "Did not create destination")
++		assert.Assert(t, fileinfo.IsDir(), "Should have been a dir, seems it's not")
++
++		err = createIfNotExists(rootFd, "tocreate", true)
++		assert.NilError(t, err, "Should not fail if already exists")
++	})
++	t.Run("file", func(t *testing.T) {
++		dir := t.TempDir()
++		rootFd := openRootFd(t, dir)
++		defer unix.Close(rootFd)
++
++		err := createIfNotExists(rootFd, "file/to/create", false)
++		assert.NilError(t, err)
++
++		fileinfo, err := os.Stat(filepath.Join(dir, "file/to/create"))
++		assert.NilError(t, err, "Did not create destination")
++
++		assert.Assert(t, !fileinfo.IsDir(), "Should have been a file, but created a directory")
++
++		err = createIfNotExists(rootFd, "file/to/create", false)
++		assert.NilError(t, err, "Should not fail if already exists")
++	})
++}
++
++func openRootFd(t *testing.T, path string) int {
++	t.Helper()
++	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
++	assert.NilError(t, err)
++	return fd
++}

--- a/recipes-containers/docker/files/CVE-2026-42306_p1.patch
+++ b/recipes-containers/docker/files/CVE-2026-42306_p1.patch
@@ -1,0 +1,183 @@
+From b4eb1144ac13d0a8e1b7d7e6a3d35ce97865d036 Mon Sep 17 00:00:00 2001
+From: Deepak Rathore <deeratho@cisco.com>
+Date: Tue, 30 Jun 2026 05:17:49 -0700
+Subject: [PATCH] Fix bind mount target redirection via symlink swap during
+ docker cp
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Pin mount targets via /proc/self/fd file descriptors to prevent TOCTOU
+attacks.
+
+Previously, a container process could swap a path component with a
+symlink between GetResourcePath resolution and directory/file creation
+or mount, allowing writes to arbitrary host paths outside the container.
+
+Open the resolved destination through os.Root to get a pinned fd, then
+mount onto /proc/self/fd/<fd> instead of re-resolving the
+container-relative path. This closes the TOCTOU window between
+createIfNotExists and mount.
+
+Because the kernel rejects remount and propagation-change syscalls on
+/proc/self/fd paths, the initial bind mount uses the fd path for safety,
+then Readlink resolves the real path for the subsequent read-only
+remount and rprivate propagation change.
+
+CVE: CVE-2026-42306
+Upstream-Status: Backport [https://github.com/moby/moby/commit/63772fe8630ee74f7c45d20637f3161cc750f4da]
+
+Backport Changes:
+- Replaced upstream root.Open with the Scarthgap openInRoot helper,
+  which uses openat(2) and O_NOFOLLOW from a pinned container-root fd
+  because Go 1.22 does not provide os.Root.
+- Used a raw O_PATH fd and /proc/self/fd/<fd> for the initial bind
+  mount, then kept the upstream real-path remount and propagation flow.
+- Kept raw fd close handling explicit: fatal paths close before
+  returning, while non-fatal makeMountRRO errors fall through to the
+  common close so targetFd is closed exactly once.
+- Retained the strings import because pathComponents still uses
+  strings.Split in the Scarthgap openat(2) helper; upstream removes it
+  because os.Root avoids that helper.
+
+Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>
+(cherry picked from commit 43fa458a9c40873867e75221454de10709b04236)
+Signed-off-by: Cory Snider <csnider@mirantis.com>
+(cherry picked from commit 63772fe8630ee74f7c45d20637f3161cc750f4da)
+Signed-off-by: Deepak Rathore <deeratho@cisco.com>
+---
+ daemon/containerfs_linux.go | 67 ++++++++++++++++++++++----
+ 1 file changed, 57 insertions(+), 10 deletions(-)
+
+diff --git a/daemon/containerfs_linux.go b/daemon/containerfs_linux.go
+index ab6b199..3ed4a88 100644
+--- a/daemon/containerfs_linux.go
++++ b/daemon/containerfs_linux.go
+@@ -7,6 +7,7 @@ import (
+ 	"os"
+ 	"path/filepath"
+ 	"runtime"
++	"strconv"
+ 	"strings"
+ 
+ 	"github.com/containerd/log"
+@@ -89,10 +90,14 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
+ 			}
+ 			defer unix.Close(rootFd)
+ 
++			// TODO(vvoland): Refactor this after security release.
+ 			for _, m := range mounts {
+-				dest, err := container.GetResourcePath(m.Destination)
++				// Destination is an absolute path within container
++				// filesystem. For the root-scoped openat operations to
++				// work, convert it to a path relative to root fs /.
++				relDest, err := filepath.Rel("/", m.Destination)
+ 				if err != nil {
+-					return err
++					return fmt.Errorf("make destination relative: %w", err)
+ 				}
+ 
+ 				var stat os.FileInfo
+@@ -100,7 +105,7 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
+ 				if err != nil {
+ 					return err
+ 				}
+-				if err := createIfNotExists(rootFd, strings.TrimPrefix(m.Destination, "/"), stat.IsDir()); err != nil {
++				if err := createIfNotExists(rootFd, relDest, stat.IsDir()); err != nil {
+ 					return err
+ 				}
+ 
+@@ -108,9 +113,7 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
+ 				if m.NonRecursive {
+ 					bindMode = "bind"
+ 				}
+-				writeMode := "ro"
+ 				if m.Writable {
+-					writeMode = "rw"
+ 					if m.ReadOnlyNonRecursive {
+ 						return errors.New("options conflict: Writable && ReadOnlyNonRecursive")
+ 					}
+@@ -122,6 +125,37 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
+ 					return errors.New("options conflict: ReadOnlyNonRecursive && ReadOnlyForceRecursive")
+ 				}
+ 
++				// Open the mount target through the container root so we
++				// have a file descriptor pinning the resolved inode. Using
++				// /proc/self/fd/<fd> as the mount target prevents any
++				// subsequent symlink swap from redirecting the mount.
++				targetFd, err := openInRoot(rootFd, relDest)
++				if err != nil {
++					return fmt.Errorf("open mount target %q: %w", m.Destination, err)
++				}
++				targetPath := "/proc/self/fd/" + strconv.Itoa(targetFd)
++
++				// The kernel rejects remount and propagation-change syscalls
++				// when the target is a /proc/self/fd path. Only the initial
++				// bind mount works on such paths, so we perform that via the
++				// fd path for TOCTOU safety and then resolve the real path for
++				// the read-only remount and propagation change.
++				if err := mount.Mount(m.Source, targetPath, "", bindMode); err != nil {
++					unix.Close(targetFd)
++					return err
++				}
++				realPath, err := os.Readlink(targetPath)
++				if err != nil {
++					unix.Close(targetFd)
++					return fmt.Errorf("readlink %s: %w", targetPath, err)
++				}
++				if !m.Writable {
++					if err := mount.Mount("", realPath, "", "ro,remount,bind"); err != nil {
++						unix.Close(targetFd)
++						return err
++					}
++				}
++
+ 				// openContainerFS() is called for temporary mounts
+ 				// outside the container. Soon these will be unmounted
+ 				// with lazy unmount option and given we have mounted
+@@ -132,20 +166,21 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
+ 				// all these mounts rprivate.  Do not use propagation
+ 				// property of volume as that should apply only when
+ 				// mounting happens inside the container.
+-				opts := strings.Join([]string{bindMode, writeMode, "rprivate"}, ",")
+-				if err := mount.Mount(m.Source, dest, "", opts); err != nil {
++				if err := mount.MakeRPrivate(realPath); err != nil {
++					unix.Close(targetFd)
+ 					return err
+ 				}
+ 
+ 				if !m.Writable && !m.ReadOnlyNonRecursive {
+-					if err := makeMountRRO(dest); err != nil {
++					if err := makeMountRRO(realPath); err != nil {
+ 						if m.ReadOnlyForceRecursive {
++							unix.Close(targetFd)
+ 							return err
+-						} else {
+-							log.G(context.TODO()).WithError(err).Debugf("Failed to make %q recursively read-only", dest)
+ 						}
++						log.G(context.TODO()).WithError(err).Debugf("Failed to make %q recursively read-only", m.Destination)
+ 					}
+ 				}
++				unix.Close(targetFd)
+ 			}
+ 
+ 			return mounttree.SwitchRoot(container.BaseFS)
+@@ -278,6 +313,18 @@ func createIfNotExists(rootFd int, unsafePath string, isDir bool) error {
+ 	return unix.Close(fd)
+ }
+ 
++func openInRoot(rootFd int, unsafePath string) (int, error) {
++	parentFd, base, closeParent, err := openParentInRoot(rootFd, unsafePath)
++	if err != nil {
++		return -1, err
++	}
++	if closeParent {
++		defer unix.Close(parentFd)
++	}
++
++	return unix.Openat(parentFd, base, unix.O_PATH|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
++}
++
+ func mkdirAllInRoot(rootFd int, unsafePath string) error {
+ 	parts, err := pathComponents(unsafePath)
+ 	if err != nil {

--- a/recipes-containers/docker/files/CVE-2026-42306_p2.patch
+++ b/recipes-containers/docker/files/CVE-2026-42306_p2.patch
@@ -1,0 +1,161 @@
+From 5ec5db4aa88385b86df0f4e109ecabde25498b2c Mon Sep 17 00:00:00 2001
+From: Deepak Rathore <deeratho@cisco.com>
+Date: Tue, 30 Jun 2026 05:19:01 -0700
+Subject: [PATCH] daemon: resolve in-container symlinks before os.Root mount ops
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The security fix in GHSA-vp62-88p7-qqf5 switched openContainerFS to
+os.Root for mount-destination operations, but stopped walking the
+destination through in-container symlinks.
+
+os.Root refuses to follow absolute symlinks, so any container whose
+image had an absolute symlink along the mount target's path (e.g. the
+common /var/run -> /run in ubuntu/alpine/busybox) broke `docker cp`.
+
+Walk m.Destination through ctr.GetResourcePath first which follows
+symlinks to get a path relative to BaseFS, then keep using os.Root for
+the actual MkdirAll/OpenFile/Open calls.
+
+CVE: CVE-2026-42306
+Upstream-Status: Backport [https://github.com/moby/moby/commit/f82f5a92d2ca3a2337b167bdc0a91d99a89756ef]
+
+Backport Changes:
+- Reworded upstream os.Root comments only where this branch uses the
+  Scarthgap openat(2)-based root-scoped helpers from p1.
+- Added an Fstat check after O_PATH|O_NOFOLLOW so a final symlink fd is
+  rejected, matching the intended os.Root.Open behavior.
+- Ported upstream TestCopyWithAbsoluteSymlinkedMountTarget from
+  integration/container/copy_linux_test.go into Scarthgap's
+  integration/container/copy_test.go, where the copy integration tests
+  live in this branch.
+
+Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>
+(cherry picked from commit fb3702d033601bb0e767f2ca398e3909a15be29c)
+Signed-off-by: Cory Snider <csnider@mirantis.com>
+(cherry picked from commit f82f5a92d2ca3a2337b167bdc0a91d99a89756ef)
+Signed-off-by: Deepak Rathore <deeratho@cisco.com>
+---
+ daemon/containerfs_linux.go        | 29 +++++++++++++++++++++-----
+ integration/container/copy_test.go | 49 ++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 73 insertions(+), 5 deletions(-)
+
+diff --git a/daemon/containerfs_linux.go b/daemon/containerfs_linux.go
+index 3ed4a88..f7ed847 100644
+--- a/daemon/containerfs_linux.go
++++ b/daemon/containerfs_linux.go
+@@ -92,10 +92,16 @@ func (daemon *Daemon) openContainerFS(container *container.Container) (_ *contai
+ 
+ 			// TODO(vvoland): Refactor this after security release.
+ 			for _, m := range mounts {
+-				// Destination is an absolute path within container
+-				// filesystem. For the root-scoped openat operations to
+-				// work, convert it to a path relative to root fs /.
+-				relDest, err := filepath.Rel("/", m.Destination)
++				// Walk m.Destination through the container's symlinks
++				// before passing it to root-scoped openat operations.
++				// This preserves common absolute symlinks such as
++				// /var/run -> /run while later fd-based operations still
++				// enforce the mount destination protections.
++				resolved, err := container.GetResourcePath(m.Destination)
++				if err != nil {
++					return fmt.Errorf("resolve mount destination %q: %w", m.Destination, err)
++				}
++				relDest, err := filepath.Rel(container.BaseFS, resolved)
+ 				if err != nil {
+ 					return fmt.Errorf("make destination relative: %w", err)
+ 				}
+@@ -322,7 +328,20 @@ func openInRoot(rootFd int, unsafePath string) (int, error) {
+ 		defer unix.Close(parentFd)
+ 	}
+ 
+-	return unix.Openat(parentFd, base, unix.O_PATH|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
++	fd, err := unix.Openat(parentFd, base, unix.O_PATH|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
++	if err != nil {
++		return -1, err
++	}
++	var st unix.Stat_t
++	if err := unix.Fstat(fd, &st); err != nil {
++		unix.Close(fd)
++		return -1, err
++	}
++	if st.Mode&unix.S_IFMT == unix.S_IFLNK {
++		unix.Close(fd)
++		return -1, fmt.Errorf("mount target %q is a symlink", unsafePath)
++	}
++	return fd, nil
+ }
+ 
+ func mkdirAllInRoot(rootFd int, unsafePath string) error {
+diff --git a/integration/container/copy_test.go b/integration/container/copy_test.go
+index 38d2c799f2..a03cc38b03 100644
+--- a/integration/container/copy_test.go
++++ b/integration/container/copy_test.go
+@@ -10,10 +10,13 @@ import (
+ 	"testing"
+ 
+ 	"github.com/docker/docker/api/types"
++	mounttypes "github.com/docker/docker/api/types/mount"
+ 	"github.com/docker/docker/errdefs"
++	"github.com/docker/docker/integration/internal/build"
+ 	"github.com/docker/docker/integration/internal/container"
+ 	"github.com/docker/docker/pkg/archive"
+ 	"github.com/docker/docker/pkg/jsonmessage"
++	"github.com/docker/docker/testutil"
+ 	"github.com/docker/docker/testutil/fakecontext"
+ 	"gotest.tools/v3/assert"
+ 	is "gotest.tools/v3/assert/cmp"
+@@ -129,6 +132,52 @@ func TestCopyToContainerPathIsNotDir(t *testing.T) {
+ 	assert.Check(t, is.ErrorContains(err, "not a directory"))
+ }
+ 
++// TestCopyWithAbsoluteSymlinkedMountTarget was introduced as a regression test
++// for https://github.com/moby/moby/issues/52653.
++//
++// The security fix in GHSA-vp62-88p7-qqf5 switched openContainerFS to use
++// os.Root for the mount-destination operations.
++// os.Root refuses to follow absolute symlinks, but distro images commonly ship
++// /var/run as an absolute symlink to /run.
++// As a result, any container with a bind mount whose target traversed such a
++// symlink (e.g. -v /host/sock:/var/run/docker.sock) made `docker cp` fail.
++func TestCopyWithAbsoluteSymlinkedMountTarget(t *testing.T) {
++	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
++	ctx := setupTest(t)
++	apiClient := testEnv.APIClient()
++
++	// Build an image with an absolute in-container symlink along the mount
++	// target path.
++	// Stock distro images expose this shape via /var/run -> /run, but we set
++	// up our own /sockets -> /root pair so the test does not depend on any
++	// particular base image's layout.
++	buildCtx := fakecontext.New(t, "",
++		fakecontext.WithDockerfile(`FROM busybox
++RUN touch /root/nil && ln -s /root /sockets
++`),
++	)
++	defer buildCtx.Close()
++	imgID := build.Do(ctx, t, apiClient, buildCtx)
++
++	// Use testutil.TempDir so the rootless daemon can access the bind-mount
++	// source: t.TempDir() creates a 0700 parent that the fake-root user
++	// cannot stat.
++	srcDir := testutil.TempDir(t)
++	assert.NilError(t, os.WriteFile(filepath.Join(srcDir, "sock"), nil, 0o644))
++
++	cid := container.Create(ctx, t, apiClient,
++		container.WithImage(imgID),
++		container.WithMount(mounttypes.Mount{
++			Type:   mounttypes.TypeBind,
++			Source: filepath.Join(srcDir, "sock"),
++			Target: "/sockets/docker.sock",
++		}),
++	)
++
++	err := apiClient.CopyToContainer(ctx, cid, "/sockets/", bytes.NewReader(nil), types.CopyToContainerOptions{})
++	assert.NilError(t, err)
++}
++
+ func TestCopyFromContainer(t *testing.T) {
+ 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+ 	ctx := setupTest(t)

--- a/recipes-containers/podman/podman/CVE-2026-55686-dependent.patch
+++ b/recipes-containers/podman/podman/CVE-2026-55686-dependent.patch
@@ -1,0 +1,53 @@
+From 757c798d8fd8ee2b05a7f0b5df753b37c7169a49 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Wed, 3 Dec 2025 16:57:15 +0100
+Subject: [PATCH 1/2] libpod: fix workdir MkdirAll() all check
+
+MkdirAll can fail with EEXIST when the path is a symlink and the target
+doesn't exist. As such we should ignore the error.
+
+Note there is something fundemantal wrong here with the path access as
+it is following the symlink to the host, however it is only for a
+stat() so it is not an security issue here.
+
+Fixes: 637c264e2e ("fix issues found by nilness")
+
+CVE: CVE-2026-55686
+Upstream-Status: Backport [https://github.com/podman-container-tools/podman/commit/e576e002e9d95ae6b37265d9e0b3deaa4c43d73f]
+
+Backport Changes:
+- Omitted the libpod/container_internal_common.go hunk because
+  Scarthgap already has equivalent os.IsExist(err) handling in the
+  resolveWorkDir() os.MkdirAll() error path.
+- Kept the upstream symlinked-workdir e2e test because the CVE fix
+  commit extends this test upstream.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+(cherry picked from commit e576e002e9d95ae6b37265d9e0b3deaa4c43d73f)
+Signed-off-by: Deepak Rathore <deeratho@cisco.com>
+---
+ test/e2e/run_working_dir_test.go | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/test/e2e/run_working_dir_test.go b/test/e2e/run_working_dir_test.go
+index 9f06df9313..53040cd98c 100644
+--- a/test/e2e/run_working_dir_test.go
++++ b/test/e2e/run_working_dir_test.go
+@@ -56,4 +56,14 @@ WORKDIR  /etc/foobar`, ALPINE)
+ 		Expect(session).Should(ExitCleanly())
+ 		Expect(session.OutputToString()).To(Equal("/home/foobar"))
+ 	})
++
++	It("podman run on an image with a symlinked workdir", func() {
++		dockerfile := fmt.Sprintf(`FROM %s
++RUN mkdir /A && ln -s /A /B
++WORKDIR /B`, ALPINE)
++		podmanTest.BuildImage(dockerfile, "test", "false")
++
++		session := podmanTest.PodmanExitCleanly("run", "test", "pwd")
++		Expect(session.OutputToString()).To(Equal("/A"))
++	})
+ })
+-- 
+2.35.6
+

--- a/recipes-containers/podman/podman/CVE-2026-55686.patch
+++ b/recipes-containers/podman/podman/CVE-2026-55686.patch
@@ -1,0 +1,190 @@
+From 7548d6714dee9c43f437202dc3d3652e89a99ee1 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Wed, 3 Dec 2025 19:15:24 +0100
+Subject: [PATCH 2/2] libpod: simplify resolveWorkDir()
+
+The code checks for isPathOnVolume and isPathOnMount so we can just use
+the SecureJoin here directly to check for path existance.
+
+Then instead of walking symlinks and trying to guess if they are on a
+mount just assume if it is a link (path is different from the normal
+joined one) then don't error out early and let the OCI runtime deal with
+it. The runtime does produce a less readable error but it still fails
+and we have much less fragile code.
+
+CVE: CVE-2026-55686
+Upstream-Status: Backport [https://github.com/podman-container-tools/podman/commit/7ce2e00ab140c11a68301f0b161f51984131a858]
+
+Backport Changes:
+- Applied the upstream SecureJoin-based resolveWorkDir() change to
+  Scarthgap's older v5.0 function shape, replacing its
+  isWorkDirSymlink()/resolvePath() flow with the same security behavior.
+- Kept Scarthgap's existing os.MkdirAll(..., 0755) and os.IsExist(err)
+  context because the equivalent prerequisite behavior is already present
+  and is documented in CVE-2026-55686-dependent.patch.
+- Kept Scarthgap's existing gexec import while applying the upstream
+  symlinked-workdir test extension.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+(cherry picked from commit 7ce2e00ab140c11a68301f0b161f51984131a858)
+Signed-off-by: Deepak Rathore <deeratho@cisco.com>
+---
+ libpod/container_internal_common.go | 81 +++++++----------------------
+ test/e2e/run_working_dir_test.go    | 24 ++++++++-
+ 2 files changed, 41 insertions(+), 64 deletions(-)
+
+diff --git a/libpod/container_internal_common.go b/libpod/container_internal_common.go
+index 3bb6dfe1eb..cfdaf1a148 100644
+--- a/libpod/container_internal_common.go
++++ b/libpod/container_internal_common.go
+@@ -688,54 +688,6 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
+ 	return g.Config, cleanupFunc, nil
+ }
+ 
+-// isWorkDirSymlink returns true if resolved workdir is symlink or a chain of symlinks,
+-// and final resolved target is present either on  volume, mount or inside of container
+-// otherwise it returns false. Following function is meant for internal use only and
+-// can change at any point of time.
+-func (c *Container) isWorkDirSymlink(resolvedPath string) bool {
+-	// We cannot create workdir since explicit --workdir is
+-	// set in config but workdir could also be a symlink.
+-	// If it's a symlink, check if the resolved target is present in the container.
+-	// If so, that's a valid use case: return nil.
+-
+-	maxSymLinks := 0
+-	for {
+-		// Linux only supports a chain of 40 links.
+-		// Reference: https://github.com/torvalds/linux/blob/master/include/linux/namei.h#L13
+-		if maxSymLinks > 40 {
+-			break
+-		}
+-		resolvedSymlink, err := os.Readlink(resolvedPath)
+-		if err != nil {
+-			// End sym-link resolution loop.
+-			break
+-		}
+-		if resolvedSymlink != "" {
+-			_, resolvedSymlinkWorkdir, err := c.resolvePath(c.state.Mountpoint, resolvedSymlink)
+-			if isPathOnVolume(c, resolvedSymlinkWorkdir) || isPathOnMount(c, resolvedSymlinkWorkdir) {
+-				// Resolved symlink exists on external volume or mount
+-				return true
+-			}
+-			if err != nil {
+-				// Could not resolve path so end sym-link resolution loop.
+-				break
+-			}
+-			if resolvedSymlinkWorkdir != "" {
+-				resolvedPath = resolvedSymlinkWorkdir
+-				_, err := os.Stat(resolvedSymlinkWorkdir)
+-				if err == nil {
+-					// Symlink resolved successfully and resolved path exists on container,
+-					// this is a valid use-case so return nil.
+-					logrus.Debugf("Workdir is a symlink with target to %q and resolved symlink exists on container", resolvedSymlink)
+-					return true
+-				}
+-			}
+-		}
+-		maxSymLinks++
+-	}
+-	return false
+-}
+-
+ // resolveWorkDir resolves the container's workdir and, depending on the
+ // configuration, will create it, or error out if it does not exist.
+ // Note that the container must be mounted before.
+@@ -750,7 +702,7 @@ func (c *Container) resolveWorkDir() error {
+ 		return nil
+ 	}
+ 
+-	_, resolvedWorkdir, err := c.resolvePath(c.state.Mountpoint, workdir)
++	resolvedWorkdir, err := securejoin.SecureJoin(c.state.Mountpoint, workdir)
+ 	if err != nil {
+ 		return err
+ 	}
+@@ -766,20 +718,23 @@ func (c *Container) resolveWorkDir() error {
+ 	if !c.config.CreateWorkingDir {
+ 		// No need to create it (e.g., `--workdir=/foo`), so let's make sure
+ 		// the path exists on the container.
+-		if err != nil {
+-			if os.IsNotExist(err) {
+-				// If resolved Workdir path gets marked as a valid symlink,
+-				// return nil cause this is valid use-case.
+-				if c.isWorkDirSymlink(resolvedWorkdir) {
+-					return nil
+-				}
+-				return fmt.Errorf("workdir %q does not exist on container %s", workdir, c.ID())
+-			}
+-			// This might be a serious error (e.g., permission), so
+-			// we need to return the full error.
+-			return fmt.Errorf("detecting workdir %q on container %s: %w", workdir, c.ID(), err)
+-		}
+-		return nil
++		if errors.Is(err, os.ErrNotExist) {
++			// Check if path is a symlink, securejoin resolves and follows the links
++			// so the path will be different from the normal join if it is one.
++			if resolvedWorkdir != filepath.Join(c.state.Mountpoint, workdir) {
++				// Path must be a symlink to non existing directory.
++				// It could point to mounts that are only created later so that make
++				// an assumption here and let's just continue and let the oci runtime
++				// do its job.
++				return nil
++			}
++			// If they are the same we know there is no symlink/relative path involved.
++			// We can return a nicer error message without having to go through the OCI runtime.
++			return fmt.Errorf("workdir %q does not exist on container %s", workdir, c.ID())
++		}
++		// This might be a serious error (e.g., permission), so
++		// we need to return the full error.
++		return fmt.Errorf("detecting workdir %q on container %s: %w", workdir, c.ID(), err)
+ 	}
+ 	if err := os.MkdirAll(resolvedWorkdir, 0755); err != nil {
+ 		if os.IsExist(err) {
+diff --git a/test/e2e/run_working_dir_test.go b/test/e2e/run_working_dir_test.go
+index 53040cd98c..ff9eeac50c 100644
+--- a/test/e2e/run_working_dir_test.go
++++ b/test/e2e/run_working_dir_test.go
+@@ -9,6 +9,7 @@ import (
+ 	. "github.com/onsi/ginkgo/v2"
+ 	. "github.com/onsi/gomega"
+ 	. "github.com/onsi/gomega/gexec"
++	"github.com/onsi/gomega/types"
+ )
+ 
+ var _ = Describe("Podman run", func() {
+@@ -59,11 +60,32 @@ WORKDIR  /etc/foobar`, ALPINE)
+ 
+ 	It("podman run on an image with a symlinked workdir", func() {
+ 		dockerfile := fmt.Sprintf(`FROM %s
+-RUN mkdir /A && ln -s /A /B
++RUN mkdir /A && ln -s /A /B && ln -s /vol/test /link
+ WORKDIR /B`, ALPINE)
+ 		podmanTest.BuildImage(dockerfile, "test", "false")
+ 
+ 		session := podmanTest.PodmanExitCleanly("run", "test", "pwd")
+ 		Expect(session.OutputToString()).To(Equal("/A"))
++
++		path := filepath.Join(podmanTest.TempDir, "test")
++		err := os.Mkdir(path, 0o755)
++		Expect(err).ToNot(HaveOccurred())
++
++		session = podmanTest.PodmanExitCleanly("run", "--workdir=/link", "--volume", podmanTest.TempDir+":/vol", "test", "pwd")
++		Expect(session.OutputToString()).To(Equal("/vol/test"))
++
++		// This will fail in the runtime since the target doesn't exists
++		session = podmanTest.Podman([]string{"run", "--workdir=/link", "test", "pwd"})
++		session.WaitWithDefaultTimeout()
++		var matcher types.GomegaMatcher
++		if filepath.Base(podmanTest.OCIRuntime) == "crun" {
++			matcher = ExitWithError(127, "chdir to `/link`: No such file or directory")
++		} else if filepath.Base(podmanTest.OCIRuntime) == "runc" {
++			matcher = ExitWithError(126, "mkdir /link: file exists")
++		} else {
++			// unknown runtime, just check it failed
++			matcher = Not(ExitCleanly())
++		}
++		Expect(session).Should(matcher)
+ 	})
+ })
+-- 
+2.35.6
+

--- a/recipes-containers/podman/podman_git.bb
+++ b/recipes-containers/podman/podman_git.bb
@@ -24,6 +24,8 @@ SRC_URI = " \
     file://0001-Use-securejoin.SecureJoin-when-forming-userns-paths.patch;patchdir=src/import/vendor/github.com/containers/storage \
     file://CVE-2025-6032.patch;patchdir=src/import \
     file://CVE-2024-9341.patch;patchdir=src/import \
+    file://CVE-2026-55686-dependent.patch;patchdir=src/import \
+    file://CVE-2026-55686.patch;patchdir=src/import \
 "
 
 LICENSE = "Apache-2.0"

--- a/recipes-containers/runc/files/CVE-2026-41579.patch
+++ b/recipes-containers/runc/files/CVE-2026-41579.patch
@@ -1,0 +1,109 @@
+From 4662e4af4680996b7d9b7100b5970b75ee6d0048 Mon Sep 17 00:00:00 2001
+From: Deepak Rathore <deeratho@cisco.com>
+Date: Mon, 6 Jul 2026 00:44:51 -0700
+Subject: [PATCH] rootfs: make /dev initialisation code fd-based
+
+These code paths operate on host-visible paths before pivot_root(2),
+so a malicious image with /dev as a symlink can make runc operate on
+host paths while setting up /dev symlinks and /dev/ptmx.
+
+Use fd-relative unlinkat(2) and symlinkat(2) against a no-follow
+opened rootfs/dev directory so the final /dev component cannot be a
+symlink to a host directory.
+
+CVE: CVE-2026-41579
+Upstream-Status: Backport [https://github.com/opencontainers/runc/commit/a8e53f2c6d6d25cb3dd643cc514f118aab44b097]
+
+Backport Changes:
+- Scarthgap runc 1.1.14 does not contain the internal/pathrs helpers
+  used by the upstream release-1.3 fix.
+- Added a minimal openDevInRoot helper and used unlinkat/symlinkat
+  directly to keep the same fd-scoped security behavior.
+- Omitted internal/pathrs changes because that package is absent from
+  release-1.1 and the CVE path only needs fixed /dev entry handling.
+
+Signed-off-by: Aleksa Sarai <aleksa@amutable.com>
+(cherry picked from commit a8e53f2c6d6d25cb3dd643cc514f118aab44b097)
+Signed-off-by: Deepak Rathore <deeratho@cisco.com>
+---
+ src/import/libcontainer/rootfs_linux.go | 45 ++++++++++++++++++++++++++----------
+ 1 file changed, 33 insertions(+), 12 deletions(-)
+
+diff --git a/src/import/libcontainer/rootfs_linux.go b/src/import/libcontainer/rootfs_linux.go
+index 78b6998c..b8f9b238 100644
+--- a/src/import/libcontainer/rootfs_linux.go
++++ b/src/import/libcontainer/rootfs_linux.go
+@@ -658,25 +658,40 @@ func checkProcMount(rootfs, dest string, m *configs.Mount, source string) error
+ 	return fmt.Errorf("%q cannot be mounted because it is inside /proc", dest)
+ }
+ 
++func openDevInRoot(rootfs string) (int, error) {
++	devPath := filepath.Join(rootfs, "dev")
++	devFd, err := unix.Open(devPath, unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
++	if err != nil {
++		return -1, &os.PathError{Op: "open", Path: devPath, Err: err}
++	}
++	return devFd, nil
++}
++
+ func setupDevSymlinks(rootfs string) error {
++	devFd, err := openDevInRoot(rootfs)
++	if err != nil {
++		return err
++	}
++	defer unix.Close(devFd) //nolint: errcheck
++
+ 	links := [][2]string{
+-		{"/proc/self/fd", "/dev/fd"},
+-		{"/proc/self/fd/0", "/dev/stdin"},
+-		{"/proc/self/fd/1", "/dev/stdout"},
+-		{"/proc/self/fd/2", "/dev/stderr"},
++		{"/proc/self/fd", "fd"},
++		{"/proc/self/fd/0", "stdin"},
++		{"/proc/self/fd/1", "stdout"},
++		{"/proc/self/fd/2", "stderr"},
+ 	}
+ 	// kcore support can be toggled with CONFIG_PROC_KCORE; only create a symlink
+ 	// in /dev if it exists in /proc.
+ 	if _, err := os.Stat("/proc/kcore"); err == nil {
+-		links = append(links, [2]string{"/proc/kcore", "/dev/core"})
++		links = append(links, [2]string{"/proc/kcore", "core"})
+ 	}
+ 	for _, link := range links {
+ 		var (
+ 			src = link[0]
+-			dst = filepath.Join(rootfs, link[1])
++			dst = link[1]
+ 		)
+-		if err := os.Symlink(src, dst); err != nil && !os.IsExist(err) {
+-			return err
++		if err := unix.Symlinkat(src, devFd, dst); err != nil && err != unix.EEXIST {
++			return &os.PathError{Op: "symlinkat", Path: filepath.Join(rootfs, "dev", dst), Err: err}
+ 		}
+ 	}
+ 	return nil
+@@ -886,12 +901,18 @@ func setReadonly() error {
+ }
+ 
+ func setupPtmx(config *configs.Config) error {
+-	ptmx := filepath.Join(config.Rootfs, "dev/ptmx")
+-	if err := os.Remove(ptmx); err != nil && !os.IsNotExist(err) {
++	devFd, err := openDevInRoot(config.Rootfs)
++	if err != nil {
+ 		return err
+ 	}
+-	if err := os.Symlink("pts/ptmx", ptmx); err != nil {
+-		return err
++	defer unix.Close(devFd) //nolint: errcheck
++
++	ptmx := filepath.Join(config.Rootfs, "dev", "ptmx")
++	if err := unix.Unlinkat(devFd, "ptmx", 0); err != nil && err != unix.ENOENT {
++		return &os.PathError{Op: "unlinkat", Path: ptmx, Err: err}
++	}
++	if err := unix.Symlinkat("pts/ptmx", devFd, "ptmx"); err != nil {
++		return &os.PathError{Op: "symlinkat", Path: ptmx, Err: err}
+ 	}
+ 	return nil
+ }
+-- 
+2.35.6

--- a/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/recipes-containers/runc/runc-opencontainers_git.bb
@@ -5,6 +5,7 @@ SRC_URI = " \
     git://github.com/opencontainers/runc;branch=release-1.1;protocol=https \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
     file://0001-Makefile-fix-typo-in-LDFLAGS_STATIC.patch \
+    file://CVE-2026-41579.patch \
     "
 RUNC_VERSION = "1.1.14"
 


### PR DESCRIPTION
merge: Currency merge with upstream scarthgap branch

Merge conflicts:

- The upstream runc-opencontainers: fix CVE-2026-41579 commit had a merge conflict due to us having [upgraded runc to [v1.2.7](https://github.com/ni/meta-virtualization/commit/daa963d6bed92f0f0790406d81a39f64b7a365b7) & then [v1.2.8](https://github.com/ni/meta-virtualization/commit/d99cf33a95142fcfebc40fdd6a40fc513c527ef5)] (release-1.2, and dropped the old fix-typo-in-LDFLAGS_STATIC patch), while that commit added a CVE-2026-41579.patch backported against the 1.1.14 tree — which, [per its own commit message](vscode-file://vscode-app/c:/Users/shtripat/AppData/Local/Programs/Microsoft%20VS%20Code/8a7abeba6e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), records the equivalent fd-based fix because the target release lacks the newer internal/pathrs helpers used by the upstream release-1.3 fix. I resolved the merge by keeping our 1.2.8 side and carrying the same fix as a 1.2.8-rebased backport (runc shipped no official 1.1/1.2 fix — [advisory](vscode-file://vscode-app/c:/Users/shtripat/AppData/Local/Programs/Microsoft%20VS%20Code/8a7abeba6e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)), verified to apply and build cleanly against v1.2.8.
- The rebase to 1.2.8 changed no fix logic — the + lines (fd-based openDevInRoot + symlinkat/unlinkat) are identical to upstream's. Only the diff anchors were updated: hunk line numbers, the refactored checkProcMount signature in the hunk header, and 3 surrounding context lines (a comment block present in 1.2.8 but not 1.1.14) so the patch applies to our tree.

[Original commit](https://git.yoctoproject.org/meta-virtualization/commit/?h=scarthgap&id=212f6fd91dd05f686c187a9ebe2ac0cf99eb4340) vs [commit after resolution](https://github.com/ni/meta-virtualization/commit/212f6fd91dd05f686c187a9ebe2ac0cf99eb4340).

[AB#3918183](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3918183)

### Testing
- [x] Built packagefeed-ni-core, packagegroup-ni-desirable, package-index, and nilrt-base-system-image
- [x] Installed the built image on a cRIO-9030 and confirmed the device booted
- [x] Installed runc-opencontainers on target system (x64)

<img width="1450" height="375" alt="image" src="https://github.com/user-attachments/assets/20c1cca5-bd97-4ed5-9b66-d154856bc855" />

